### PR TITLE
feat(ios): opt-in handler registration to fix App Store framework-linking rejection (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### 🛠️ Architecture & API
+
+- **Opt-in iOS handler registration (`GrantFactory.create { … }`)** — Closes the App Store rejection class re-opened by [issue #38](https://github.com/brewkits/Grant/issues/38). The previous Handler Pattern fix moved framework imports into per-permission files but `PlatformGrantDelegate.handlerFor()` still referenced every handler class in one exhaustive `when`, defeating Kotlin/Native DCE. `nm -u` on the v1.4.1 release framework still showed `_OBJC_CLASS_$_CMMotionActivityManager`, `_OBJC_CLASS_$_CNContactStore`, and `_OBJC_CLASS_$_EKEventStore` even in apps that only request Location/Bluetooth/Notification.
+
+  The new `GrantFactory.create { … }` block accepts a `GrantBuilder` and per-permission extension functions (`location()`, `locationAlways()`, `bluetooth()`, `notification()`, `camera()`, …). Each `actual fun` references only the handler classes for its permission family. When a consumer omits an extension, the K/N linker walks the call graph, finds nothing reachable for that handler, and DCEs the handler class along with its `import platform.X.*` statements — taking the unused frameworks out of the final binary. Apple's static analyzer then no longer demands `NSUsageDescription` keys for frameworks the app never uses.
+
+  ```kotlin
+  // New (recommended): only LOCATION, LOCATION_ALWAYS, BLUETOOTH, NOTIFICATION
+  // CoreMotion, EventKit, Contacts not linked.
+  val grantManager = GrantFactory.create {
+      location()
+      locationAlways()
+      bluetooth()
+      notification()
+  }
+  ```
+
+- **`GrantFactory.create()` (no-arg) deprecated** — Kept working via a backward-compat shim that calls `registerAll()` internally. Existing consumers continue to function with no source changes; the deprecation `ReplaceWith` quote points at the block form.
+
+- **Android parity** — `GrantBuilder` extensions are also declared `actual` for Android, but registrations are ignored on that platform (the Android delegate dispatches through the Activity Result API directly). The DSL exists primarily to gate iOS handler linking; Android consumers can use either form with no link-time effect on the APK.
+
+- **`registerAll()` helper** — Provided on `GrantBuilder` for consumers that intentionally want the legacy "all handlers linked" behavior (rare; usually only useful during migration or for libraries that wrap Grant).
+
+---
+
 ## [1.4.2] - 2026-05-14
 
 ### 🐛 Critical Bug Fixes

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantBuilder.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantBuilder.android.kt
@@ -1,0 +1,72 @@
+package dev.brewkits.grant
+
+/*
+ * Android `actual` extensions for [GrantBuilder].
+ *
+ * Android doesn't need per-permission handler classes — the
+ * `AndroidGrantDelegate` dispatches directly through Activity Result API +
+ * `ContextCompat.checkSelfPermission`. The registry produced by [GrantBuilder]
+ * is therefore ignored on Android (see `createPlatformDelegateWithRegistry`),
+ * but we still register a sentinel value so the registry isn't empty —
+ * primarily so that `commonTest` tests asserting which permissions were
+ * registered pass on Android the same way they do on iOS.
+ */
+
+private val ANDROID_NOOP: () -> Any = { Unit }
+
+actual fun GrantBuilder.camera() {
+    register(AppGrant.CAMERA, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.microphone() {
+    register(AppGrant.MICROPHONE, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.gallery() {
+    register(AppGrant.GALLERY, ANDROID_NOOP)
+    register(AppGrant.GALLERY_IMAGES_ONLY, ANDROID_NOOP)
+    register(AppGrant.GALLERY_VIDEO_ONLY, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.storage() {
+    register(AppGrant.STORAGE, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.location() {
+    register(AppGrant.LOCATION, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.locationAlways() {
+    register(AppGrant.LOCATION_ALWAYS, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.notification() {
+    register(AppGrant.NOTIFICATION, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.scheduleExactAlarm() {
+    register(AppGrant.SCHEDULE_EXACT_ALARM, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.bluetooth() {
+    register(AppGrant.BLUETOOTH, ANDROID_NOOP)
+    register(AppGrant.BLUETOOTH_ADVERTISE, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.contacts() {
+    register(AppGrant.CONTACTS, ANDROID_NOOP)
+    register(AppGrant.READ_CONTACTS, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.calendar() {
+    register(AppGrant.CALENDAR, ANDROID_NOOP)
+    register(AppGrant.READ_CALENDAR, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.motion() {
+    register(AppGrant.MOTION, ANDROID_NOOP)
+}
+
+actual fun GrantBuilder.nearbyWifiDevices() {
+    register(AppGrant.NEARBY_WIFI_DEVICES, ANDROID_NOOP)
+}

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantFactory.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantFactory.android.kt
@@ -17,3 +17,18 @@ actual fun createPlatformDelegate(context: Any?, store: GrantStore): PlatformGra
     // Even if user passes Activity context, we convert it to Application context
     return PlatformGrantDelegate(context.applicationContext, store)
 }
+
+/**
+ * Android implementation of the registry-aware factory.
+ *
+ * The registry is **ignored** on Android — the platform's runtime permission
+ * model dispatches directly through Activity Result API + `checkSelfPermission`,
+ * so there are no handler classes to opt into. The opt-in DSL exists primarily
+ * to enable Kotlin/Native DCE on iOS; Android consumers are free to use the
+ * block form, but it has no link-time effect on the resulting APK.
+ */
+actual fun createPlatformDelegateWithRegistry(
+    context: Any?,
+    store: GrantStore,
+    registrations: Map<AppGrant, () -> Any>
+): PlatformGrantDelegate = createPlatformDelegate(context, store)

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantBuilder.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantBuilder.kt
@@ -1,0 +1,143 @@
+package dev.brewkits.grant
+
+/**
+ * DSL builder used by [GrantFactory.create] to opt into the handlers an app needs.
+ *
+ * On iOS, the Kotlin/Native linker walks the call graph and links every class that is
+ * reachable from compiled code. Historically `PlatformGrantDelegate` referenced every
+ * handler class in a single `when` expression, which forced the linker to keep every
+ * handler — and every `import platform.X.*` declaration inside those handlers — alive
+ * in the final binary. Apple's static analyzer then required `NSUsageDescription`
+ * keys for frameworks the app never actually uses (CoreMotion, EventKit, Contacts, …),
+ * causing App Store rejections. See [issue #38](https://github.com/brewkits/Grant/issues/38).
+ *
+ * The fix is opt-in registration. Each per-permission extension function (e.g.
+ * [bluetooth], [location], [contacts]) lives in its own `actual` declaration and only
+ * references the handlers it needs. When a consumer omits a permission, the extension
+ * function is unreachable and the K/N linker strips the handler — along with its
+ * framework imports — from the binary.
+ *
+ * Example:
+ * ```kotlin
+ * val grantManager = GrantFactory.create {
+ *     location()
+ *     locationAlways()
+ *     bluetooth()
+ *     notification()
+ *     // contacts(), calendar(), motion() not called → those handlers are not linked.
+ * }
+ * ```
+ *
+ * @property registrations Map of [AppGrant] → factory for a platform-specific handler.
+ *   The value type is [Any] so commonMain doesn't depend on a platform-specific handler
+ *   interface; platform-specific factory implementations cast on use.
+ */
+class GrantBuilder internal constructor() {
+    /**
+     * Internal registry of permission → handler factory.
+     *
+     * The value type is `() -> Any` because commonMain cannot reference
+     * the iOS-specific `IosPermissionHandler` interface. Platform code casts on use.
+     */
+    internal val registrations: MutableMap<AppGrant, () -> Any> = mutableMapOf()
+
+    /**
+     * Registers a handler factory for a single [AppGrant].
+     *
+     * Called by the per-permission extension functions ([location], [bluetooth], …).
+     * Most consumers should call those instead of this directly.
+     */
+    fun register(grant: AppGrant, handlerFactory: () -> Any) {
+        registrations[grant] = handlerFactory
+    }
+}
+
+/**
+ * Registers handlers for every [AppGrant]. Used by the deprecated no-arg
+ * [GrantFactory.create] overload to preserve backward-compatible behavior:
+ * every handler is linked, every framework import is kept, and the existing
+ * workaround of declaring all `NSUsageDescription` keys continues to work.
+ *
+ * New code should call only the specific permission extensions it needs.
+ */
+fun GrantBuilder.registerAll() {
+    camera()
+    microphone()
+    gallery()
+    storage()
+    location()
+    locationAlways()
+    notification()
+    scheduleExactAlarm()
+    bluetooth()
+    contacts()
+    calendar()
+    motion()
+    nearbyWifiDevices()
+}
+
+// ---------------------------------------------------------------------------
+// Per-permission extension declarations.
+//
+// Each declaration is `expect` here and `actual` in iosMain / androidMain.
+// On iOS, the `actual` body references only the handler classes for that
+// permission family — the key property that lets K/N DCE remove unused
+// handlers (and their `import platform.X.*` statements) from the binary.
+// ---------------------------------------------------------------------------
+
+/** Camera (iOS: AVFoundation / NSCameraUsageDescription). */
+expect fun GrantBuilder.camera()
+
+/** Microphone (iOS: AVFoundation / NSMicrophoneUsageDescription). */
+expect fun GrantBuilder.microphone()
+
+/**
+ * Photo library — full, images-only, videos-only, and STORAGE (no-op on iOS).
+ *
+ * Registers handlers for [AppGrant.GALLERY], [AppGrant.GALLERY_IMAGES_ONLY],
+ * [AppGrant.GALLERY_VIDEO_ONLY]. iOS uses NSPhotoLibraryUsageDescription.
+ */
+expect fun GrantBuilder.gallery()
+
+/**
+ * Storage. No-op on iOS (sandbox; always GRANTED) but routed through the same
+ * Photos handler so that [AppGrant.STORAGE] dispatches correctly.
+ */
+expect fun GrantBuilder.storage()
+
+/** Foreground location (iOS: NSLocationWhenInUseUsageDescription). */
+expect fun GrantBuilder.location()
+
+/** Background location (iOS: NSLocationAlwaysAndWhenInUseUsageDescription). */
+expect fun GrantBuilder.locationAlways()
+
+/** Push & local notifications (iOS: UserNotifications). */
+expect fun GrantBuilder.notification()
+
+/** Always GRANTED on iOS — no framework linked, but covers Android API 31+. */
+expect fun GrantBuilder.scheduleExactAlarm()
+
+/**
+ * Bluetooth — central + advertise. Registers [AppGrant.BLUETOOTH] and
+ * [AppGrant.BLUETOOTH_ADVERTISE]. iOS: CoreBluetooth /
+ * NSBluetoothAlwaysUsageDescription.
+ */
+expect fun GrantBuilder.bluetooth()
+
+/**
+ * Contacts — full and read-only. Registers [AppGrant.CONTACTS] and
+ * [AppGrant.READ_CONTACTS]. iOS: Contacts / NSContactsUsageDescription.
+ */
+expect fun GrantBuilder.contacts()
+
+/**
+ * Calendar — full and read-only. Registers [AppGrant.CALENDAR] and
+ * [AppGrant.READ_CALENDAR]. iOS: EventKit / NSCalendarsUsageDescription.
+ */
+expect fun GrantBuilder.calendar()
+
+/** Motion & activity (iOS: CoreMotion / NSMotionUsageDescription). */
+expect fun GrantBuilder.motion()
+
+/** Always GRANTED on iOS — no framework linked. */
+expect fun GrantBuilder.nearbyWifiDevices()

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFactory.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFactory.kt
@@ -9,34 +9,79 @@ import dev.brewkits.grant.impl.PlatformGrantDelegate
  *
  * Use this for "Manual Injection" if your project does not use Koin or other DI tools.
  *
- * ### Usage Example (Android)
+ * ### Recommended usage — opt-in DSL
  * ```kotlin
- * val grantManager = GrantFactory.create(applicationContext)
+ * val grantManager = GrantFactory.create(applicationContext) {
+ *     location()
+ *     locationAlways()
+ *     bluetooth()
+ *     notification()
+ * }
  * ```
  *
- * ### Usage Example (iOS)
- * ```kotlin
- * val grantManager = GrantFactory.create()
- * ```
+ * Calling only the permissions an app actually uses lets Kotlin/Native DCE strip the
+ * other handlers and their framework imports, which prevents Apple's static analyzer
+ * from demanding unused `NSUsageDescription` keys. See
+ * [issue #38](https://github.com/brewkits/Grant/issues/38) for background.
  */
 object GrantFactory {
     /**
-     * Creates and returns a production-ready [GrantManager] instance.
+     * Creates a [GrantManager] that supports only the permissions registered inside [block].
      *
-     * @param context The platform-specific context (required on Android, ignored on iOS).
-     * @param store The storage implementation for tracking request history (defaults to [InMemoryGrantStore]).
-     * @return A fully configured [GrantManager].
+     * Any permission requested at runtime that was not registered will return an
+     * error / unsupported status — call sites should declare every permission they need.
+     *
+     * @param context Platform-specific context (required on Android, ignored on iOS).
+     * @param store Storage implementation for tracking request history.
+     * @param block DSL block that calls the per-permission extensions on [GrantBuilder].
      */
     fun create(
         context: Any? = null,
-        store: GrantStore = InMemoryGrantStore()
+        store: GrantStore = InMemoryGrantStore(),
+        block: GrantBuilder.() -> Unit
     ): GrantManager {
-        val delegate = createPlatformDelegate(context, store)
+        val builder = GrantBuilder().apply(block)
+        val delegate = createPlatformDelegateWithRegistry(context, store, builder.registrations)
         return DefaultGrantManager(delegate)
     }
+
+    /**
+     * Legacy no-arg factory.
+     *
+     * Registers every built-in handler internally, which preserves the v1.4.x linking
+     * behavior — every framework is linked, every `NSUsageDescription` key is still
+     * required. New code should switch to the block form so K/N DCE can strip
+     * handlers an app never uses.
+     */
+    @Deprecated(
+        message = "Use the block form for selective handler registration. The no-arg form " +
+            "registers every handler, which forces App Store to require NSUsageDescription " +
+            "keys for unused frameworks (CoreMotion, EventKit, Contacts). " +
+            "See https://github.com/brewkits/Grant/issues/38.",
+        replaceWith = ReplaceWith("create(context, store) { registerAll() }")
+    )
+    fun create(
+        context: Any? = null,
+        store: GrantStore = InMemoryGrantStore()
+    ): GrantManager = create(context, store) { registerAll() }
 }
 
 /**
  * Platform-specific factory function. Internal use only.
+ *
+ * @deprecated Kept for the legacy no-arg path on platforms that haven't migrated to
+ *   the registry-based delegate yet. New code goes through
+ *   [createPlatformDelegateWithRegistry].
  */
 expect fun createPlatformDelegate(context: Any?, store: GrantStore): PlatformGrantDelegate
+
+/**
+ * Platform-specific factory that wires a registry of handler factories into the
+ * delegate. iOS uses the registry as its single source of truth for permission
+ * dispatch; Android ignores the registry (its delegate maps directly to native APIs).
+ */
+expect fun createPlatformDelegateWithRegistry(
+    context: Any?,
+    store: GrantStore,
+    registrations: Map<AppGrant, () -> Any>
+): PlatformGrantDelegate

--- a/grant-core/src/commonTest/kotlin/dev/brewkits/grant/GrantBuilderTest.kt
+++ b/grant-core/src/commonTest/kotlin/dev/brewkits/grant/GrantBuilderTest.kt
@@ -1,0 +1,97 @@
+package dev.brewkits.grant
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+/**
+ * Cross-platform tests for the opt-in handler-registration DSL.
+ *
+ * These tests only inspect the registry produced by [GrantBuilder]; they do
+ * not exercise the platform delegate. That keeps them runnable on Android,
+ * iOS, and JVM common tests without needing platform setup.
+ */
+class GrantBuilderTest {
+
+    @Test
+    fun emptyBlockProducesEmptyRegistry() {
+        val manager = GrantFactory.create { /* no permissions */ }
+        assertNotNull(manager, "GrantManager should be returned even for empty block")
+    }
+
+    @Test
+    fun registerAllRegistersEveryAppGrant() {
+        // Use the builder directly so we can inspect the registry contents.
+        val builder = GrantBuilder().apply { registerAll() }
+        val registered = builder.registrations.keys
+
+        AppGrant.entries.forEach { grant ->
+            assertTrue(
+                grant in registered,
+                "registerAll() must register every AppGrant; missing: ${grant.name}"
+            )
+        }
+    }
+
+    @Test
+    fun selectiveRegistrationOnlyAddsRequestedPermissions() {
+        val builder = GrantBuilder().apply {
+            location()
+            bluetooth()
+        }
+
+        assertTrue(AppGrant.LOCATION in builder.registrations)
+        assertTrue(AppGrant.BLUETOOTH in builder.registrations)
+        assertTrue(AppGrant.BLUETOOTH_ADVERTISE in builder.registrations)
+
+        // Permissions we didn't ask for must NOT appear in the registry.
+        assertFalse(AppGrant.CAMERA in builder.registrations)
+        assertFalse(AppGrant.CONTACTS in builder.registrations)
+        assertFalse(AppGrant.MOTION in builder.registrations)
+        assertFalse(AppGrant.CALENDAR in builder.registrations)
+    }
+
+    @Test
+    fun bluetoothExtensionCoversAdvertise() {
+        val builder = GrantBuilder().apply { bluetooth() }
+        assertTrue(AppGrant.BLUETOOTH in builder.registrations)
+        assertTrue(
+            AppGrant.BLUETOOTH_ADVERTISE in builder.registrations,
+            "bluetooth() must also register BLUETOOTH_ADVERTISE since both share the same handler"
+        )
+    }
+
+    @Test
+    fun contactsExtensionCoversReadContacts() {
+        val builder = GrantBuilder().apply { contacts() }
+        assertTrue(AppGrant.CONTACTS in builder.registrations)
+        assertTrue(AppGrant.READ_CONTACTS in builder.registrations)
+    }
+
+    @Test
+    fun calendarExtensionCoversReadCalendar() {
+        val builder = GrantBuilder().apply { calendar() }
+        assertTrue(AppGrant.CALENDAR in builder.registrations)
+        assertTrue(AppGrant.READ_CALENDAR in builder.registrations)
+    }
+
+    @Test
+    fun galleryExtensionCoversAllGalleryVariants() {
+        val builder = GrantBuilder().apply { gallery() }
+        assertTrue(AppGrant.GALLERY in builder.registrations)
+        assertTrue(AppGrant.GALLERY_IMAGES_ONLY in builder.registrations)
+        assertTrue(AppGrant.GALLERY_VIDEO_ONLY in builder.registrations)
+    }
+
+    @Test
+    fun registerAllAppGrantCount() {
+        val builder = GrantBuilder().apply { registerAll() }
+        assertEquals(
+            AppGrant.entries.size,
+            builder.registrations.size,
+            "registerAll() should produce one registration per AppGrant"
+        )
+    }
+}

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantBuilder.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantBuilder.ios.kt
@@ -1,0 +1,114 @@
+package dev.brewkits.grant
+
+import dev.brewkits.grant.delegates.BluetoothManagerDelegate
+import dev.brewkits.grant.delegates.LocationManagerDelegate
+import dev.brewkits.grant.handlers.AVPermissionHandler
+import dev.brewkits.grant.handlers.BluetoothPermissionHandler
+import dev.brewkits.grant.handlers.CalendarPermissionHandler
+import dev.brewkits.grant.handlers.ContactsPermissionHandler
+import dev.brewkits.grant.handlers.IosPermissionHandler
+import dev.brewkits.grant.handlers.LocationPermissionHandler
+import dev.brewkits.grant.handlers.MotionPermissionHandler
+import dev.brewkits.grant.handlers.NotificationPermissionHandler
+import dev.brewkits.grant.handlers.PhotoPermissionHandler
+
+/*
+ * iOS opt-in handler registration.
+ *
+ * Each `actual fun` in this file references ONLY the handler classes for its
+ * own permission family. The K/N linker walks the call graph; if a consumer
+ * never calls — e.g. — `contacts()`, then [ContactsPermissionHandler] is
+ * unreachable, the `import platform.Contacts.*` declaration in that file is
+ * unreachable, and the Contacts framework is not linked. Apple's static
+ * analyzer then has no basis to demand an `NSContactsUsageDescription` key.
+ *
+ * Do NOT consolidate these into a single function or a map keyed on AppGrant.
+ * Any code shape that references every handler from one site defeats the
+ * whole purpose of this file — DCE will keep them all.
+ */
+
+// Shared platform delegates are held as `by lazy` private properties on the file
+// so that location and bluetooth share one CLLocationManager / CBCentralManager
+// instance per process (matching legacy behavior). Each property only references
+// its own delegate class, so DCE rules still apply per-permission.
+private val sharedLocationDelegate by lazy { LocationManagerDelegate() }
+private val sharedBluetoothDelegate by lazy { BluetoothManagerDelegate() }
+
+actual fun GrantBuilder.camera() {
+    register(AppGrant.CAMERA) { AVPermissionHandler.camera() as IosPermissionHandler }
+}
+
+actual fun GrantBuilder.microphone() {
+    register(AppGrant.MICROPHONE) { AVPermissionHandler.microphone() as IosPermissionHandler }
+}
+
+actual fun GrantBuilder.gallery() {
+    val factory: () -> Any = { PhotoPermissionHandler() }
+    register(AppGrant.GALLERY, factory)
+    register(AppGrant.GALLERY_IMAGES_ONLY, factory)
+    register(AppGrant.GALLERY_VIDEO_ONLY, factory)
+}
+
+actual fun GrantBuilder.storage() {
+    // STORAGE on iOS is a no-op (sandbox; always GRANTED) but it dispatches through
+    // the Photos handler for parity with legacy behavior.
+    register(AppGrant.STORAGE) { PhotoPermissionHandler() }
+}
+
+actual fun GrantBuilder.location() {
+    register(AppGrant.LOCATION) {
+        LocationPermissionHandler(forAlways = false, delegate = sharedLocationDelegate)
+    }
+}
+
+actual fun GrantBuilder.locationAlways() {
+    register(AppGrant.LOCATION_ALWAYS) {
+        LocationPermissionHandler(forAlways = true, delegate = sharedLocationDelegate)
+    }
+}
+
+actual fun GrantBuilder.notification() {
+    register(AppGrant.NOTIFICATION) { NotificationPermissionHandler() }
+}
+
+actual fun GrantBuilder.scheduleExactAlarm() {
+    register(AppGrant.SCHEDULE_EXACT_ALARM) { AlwaysGrantedIosHandler }
+}
+
+actual fun GrantBuilder.bluetooth() {
+    val factory: () -> Any = { BluetoothPermissionHandler(delegate = sharedBluetoothDelegate) }
+    register(AppGrant.BLUETOOTH, factory)
+    register(AppGrant.BLUETOOTH_ADVERTISE, factory)
+}
+
+actual fun GrantBuilder.contacts() {
+    val factory: () -> Any = { ContactsPermissionHandler() }
+    register(AppGrant.CONTACTS, factory)
+    register(AppGrant.READ_CONTACTS, factory)
+}
+
+actual fun GrantBuilder.calendar() {
+    val factory: () -> Any = { CalendarPermissionHandler() }
+    register(AppGrant.CALENDAR, factory)
+    register(AppGrant.READ_CALENDAR, factory)
+}
+
+actual fun GrantBuilder.motion() {
+    register(AppGrant.MOTION) { MotionPermissionHandler() }
+}
+
+actual fun GrantBuilder.nearbyWifiDevices() {
+    register(AppGrant.NEARBY_WIFI_DEVICES) { AlwaysGrantedIosHandler }
+}
+
+/**
+ * Singleton for iOS permissions that are always GRANTED without a dialog
+ * (e.g. [AppGrant.SCHEDULE_EXACT_ALARM], [AppGrant.NEARBY_WIFI_DEVICES]).
+ * Defined here (not inside [dev.brewkits.grant.impl.PlatformGrantDelegate])
+ * so that the per-permission `actual fun`s above can reference it without
+ * pulling the delegate's other transitive imports.
+ */
+internal object AlwaysGrantedIosHandler : IosPermissionHandler {
+    override fun checkStatus(): GrantStatus = GrantStatus.GRANTED
+    override suspend fun request(): GrantStatus = GrantStatus.GRANTED
+}

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantFactory.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantFactory.ios.kt
@@ -1,13 +1,31 @@
 package dev.brewkits.grant
 
+import dev.brewkits.grant.handlers.IosPermissionHandler
 import dev.brewkits.grant.impl.PlatformGrantDelegate
 
 /**
  * iOS implementation of platform delegate factory.
  *
  * Accepts GrantStore for state management (in-memory only on iOS).
+ *
+ * This legacy factory registers every built-in handler so existing consumers
+ * remain functional. Apps that want K/N DCE to strip unused handlers should
+ * switch to [GrantFactory.create] with the block form.
  */
 actual fun createPlatformDelegate(context: Any?, store: GrantStore): PlatformGrantDelegate {
     // iOS doesn't use context, only store
     return PlatformGrantDelegate(store)
+}
+
+actual fun createPlatformDelegateWithRegistry(
+    context: Any?,
+    store: GrantStore,
+    registrations: Map<AppGrant, () -> Any>
+): PlatformGrantDelegate {
+    @Suppress("UNCHECKED_CAST")
+    val typedRegistrations: Map<AppGrant, () -> IosPermissionHandler> =
+        registrations.mapValues { (_, factory) ->
+            { factory() as IosPermissionHandler }
+        }
+    return PlatformGrantDelegate(store, typedRegistrations)
 }

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
@@ -1,23 +1,16 @@
 package dev.brewkits.grant.impl
 
 import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantBuilder
 import dev.brewkits.grant.GrantPermission
 import dev.brewkits.grant.GrantStatus
 import dev.brewkits.grant.GrantStore
 import dev.brewkits.grant.GrantLauncher
 import dev.brewkits.grant.RawPermission
-import dev.brewkits.grant.delegates.BluetoothManagerDelegate
-import dev.brewkits.grant.delegates.LocationManagerDelegate
-import dev.brewkits.grant.handlers.AVPermissionHandler
-import dev.brewkits.grant.handlers.BluetoothPermissionHandler
-import dev.brewkits.grant.handlers.CalendarPermissionHandler
-import dev.brewkits.grant.handlers.ContactsPermissionHandler
 import dev.brewkits.grant.handlers.IosPermissionHandler
-import dev.brewkits.grant.handlers.LocationPermissionHandler
-import dev.brewkits.grant.handlers.MotionPermissionHandler
-import dev.brewkits.grant.handlers.NotificationPermissionHandler
-import dev.brewkits.grant.handlers.PhotoPermissionHandler
 import dev.brewkits.grant.handlers.IosPermissionHandlerRegistry
+import dev.brewkits.grant.handlers.NotificationPermissionHandler
+import dev.brewkits.grant.registerAll
 import dev.brewkits.grant.utils.GrantLogger
 import dev.brewkits.grant.utils.hasInfoPlistKey
 import dev.brewkits.grant.utils.runOnMain
@@ -38,51 +31,72 @@ import dev.brewkits.grant.utils.ReentrantMutex
 private const val TAG = "iOSGrantDelegate"
 
 /**
- * iOS Platform Grant Delegate — Production-ready implementation.
+ * iOS Platform Grant Delegate — registry-driven dispatch.
  *
- * Dispatches permission operations to dedicated [IosPermissionHandler] instances,
- * each of which owns exactly the native framework imports it needs. This ensures
- * that unused permission frameworks are **not statically linked** into the app binary,
- * preventing Apple App Store rejections caused by undeclared usage description keys.
+ * Handlers are supplied as a map of [AppGrant] → factory function. The map is
+ * populated by [GrantBuilder] (called from `GrantFactory.create { … }`) and
+ * each per-permission `actual fun` references only the handler classes for that
+ * permission family. Permissions the consumer did not register are not in the
+ * map, and the K/N linker DCEs their handler classes — along with the
+ * `import platform.X.*` declarations inside those handlers — out of the
+ * release binary. This prevents Apple's static analyzer from demanding
+ * `NSUsageDescription` keys for frameworks the app never actually uses.
  *
- * See [docs/ios/APPLE_FRAMEWORK_LINKING_ISSUE.md] for the full architectural rationale.
- *
- * **Supported permissions (17 total):**
- * - Camera / Microphone — AVFoundation
- * - Gallery / Storage   — Photos
- * - Location (WhenInUse / Always) — CoreLocation
- * - Notification        — UserNotifications
- * - Contacts            — Contacts
- * - Calendar            — EventKit
- * - Motion              — CoreMotion
- * - Bluetooth           — CoreBluetooth (via BluetoothManagerDelegate)
- * - Schedule Exact Alarm — always GRANTED on iOS
+ * See [issue #38](https://github.com/brewkits/Grant/issues/38) and
+ * `docs/ios/APPLE_FRAMEWORK_LINKING_ISSUE.md` for the architectural rationale.
  *
  * **Thread Safety:**
- * - [mutexMap] is protected by [mapsMutex]
- * - [statusCacheMap] uses per-entry locking via [mapsMutex]
+ * - [mutexMapInternal] / [statusCacheMap] guarded by [mapsMutex]
  * - All synchronous iOS framework calls dispatch to the main thread via [runOnMain]
- * - Notification status is checked via its own async path to avoid nested dispatch
+ * - Notification status uses its own async path to avoid nested dispatch
  */
 @Suppress("UnusedPrivateProperty")
-actual class PlatformGrantDelegate(
-    private val store: GrantStore
+actual class PlatformGrantDelegate internal constructor(
+    private val store: GrantStore,
+    private val handlerFactories: Map<AppGrant, () -> IosPermissionHandler>
 ) {
+    /**
+     * Legacy constructor — registers every built-in handler. Preserves
+     * pre-v1.5.0 linking behavior for callers that still use
+     * `GrantFactory.create()` (no-arg) or construct the delegate directly.
+     *
+     * The class-reachability through [registerAll] forces the K/N linker to
+     * keep every handler; this is the correct trade-off for the legacy path
+     * so existing apps don't break. Apps that need DCE savings must switch to
+     * the new `GrantFactory.create { … }` form.
+     */
+    constructor(store: GrantStore) : this(store, buildLegacyRegistry())
 
     // ====================================================================
     // Thread-safe maps
     // ====================================================================
 
-    /** Protects all map structures (mutexMapInternal, statusCacheMap). */
+    /** Protects all map structures (mutexMapInternal, statusCacheMap, handlerCache). */
     private val mapsMutex = Mutex()
     private val mutexMapInternal = mutableMapOf<String, ReentrantMutex>()
     private val statusCacheMap = mutableMapOf<String, Pair<GrantStatus, Long>>()
+
+    /** Lazy cache of instantiated handlers — each factory runs at most once. */
+    private val handlerCache = mutableMapOf<AppGrant, IosPermissionHandler>()
 
     private companion object {
         /** Status cache TTL (1000ms). */
         const val STATUS_CACHE_TTL_MS = 1000L
         /** Delay between sequential requests on iOS to avoid system throttling. */
         const val SEQUENTIAL_REQUEST_DELAY_MS = 600L
+
+        /**
+         * Builds the legacy "register everything" map used by the no-arg
+         * constructor. Importantly this calls [registerAll], which references
+         * every per-permission extension — preserving v1.4.x linking behavior
+         * so existing apps stay functional after upgrading.
+         */
+        private fun buildLegacyRegistry(): Map<AppGrant, () -> IosPermissionHandler> {
+            val builder = GrantBuilder().apply { registerAll() }
+            return builder.registrations.mapValues { (_, factory) ->
+                { factory() as IosPermissionHandler }
+            }
+        }
     }
 
     private suspend fun getMutexFor(identifier: String): ReentrantMutex =
@@ -91,27 +105,63 @@ actual class PlatformGrantDelegate(
     private fun getMonotonicTimeMillis(): Long =
         (NSProcessInfo.processInfo.systemUptime * 1000).toLong()
 
-    // ====================================================================
-    // Shared delegates (lazy — only initialized if their permission is used)
-    // ====================================================================
+    /**
+     * Returns the handler for [grant], instantiating it lazily via its
+     * registered factory. Throws an informative error if the consumer did not
+     * register the permission.
+     *
+     * NOTIFICATION has a separate async path (see [requestInternal]) but its
+     * factory still lives in the map for status calls via [notificationHandler].
+     */
+    private suspend fun handlerFor(grant: AppGrant): IosPermissionHandler =
+        mapsMutex.withLock {
+            handlerCache.getOrPut(grant) {
+                val factory = handlerFactories[grant]
+                    ?: error(
+                        "Permission ${grant.name} not registered. " +
+                            "Add ${suggestedExtension(grant)}() to your GrantFactory.create { } block, " +
+                            "or call registerAll() for the legacy behavior."
+                    )
+                factory()
+            }
+        }
 
-    private val locationDelegate by lazy { LocationManagerDelegate() }
-    private val bluetoothDelegate by lazy { BluetoothManagerDelegate() }
+    /**
+     * Maps an [AppGrant] back to the [GrantBuilder] extension that registers it.
+     * Used purely for the not-registered error message.
+     */
+    private fun suggestedExtension(grant: AppGrant): String = when (grant) {
+        AppGrant.CAMERA -> "camera"
+        AppGrant.MICROPHONE -> "microphone"
+        AppGrant.GALLERY,
+        AppGrant.GALLERY_IMAGES_ONLY,
+        AppGrant.GALLERY_VIDEO_ONLY -> "gallery"
+        AppGrant.STORAGE -> "storage"
+        AppGrant.LOCATION -> "location"
+        AppGrant.LOCATION_ALWAYS -> "locationAlways"
+        AppGrant.NOTIFICATION -> "notification"
+        AppGrant.SCHEDULE_EXACT_ALARM -> "scheduleExactAlarm"
+        AppGrant.BLUETOOTH,
+        AppGrant.BLUETOOTH_ADVERTISE -> "bluetooth"
+        AppGrant.CONTACTS,
+        AppGrant.READ_CONTACTS -> "contacts"
+        AppGrant.CALENDAR,
+        AppGrant.READ_CALENDAR -> "calendar"
+        AppGrant.MOTION -> "motion"
+        AppGrant.NEARBY_WIFI_DEVICES -> "nearbyWifiDevices"
+    }
 
-    // ====================================================================
-    // Handlers (lazy — framework code loaded only when first accessed)
-    // ====================================================================
-
-    private val cameraHandler by lazy { AVPermissionHandler.camera() }
-    private val microphoneHandler by lazy { AVPermissionHandler.microphone() }
-    private val photoHandler by lazy { PhotoPermissionHandler() }
-    private val locationWhenInUseHandler by lazy { LocationPermissionHandler(forAlways = false, delegate = locationDelegate) }
-    private val locationAlwaysHandler by lazy { LocationPermissionHandler(forAlways = true, delegate = locationDelegate) }
-    private val notificationHandler by lazy { NotificationPermissionHandler() }
-    private val contactsHandler by lazy { ContactsPermissionHandler() }
-    private val calendarHandler by lazy { CalendarPermissionHandler() }
-    private val motionHandler by lazy { MotionPermissionHandler() }
-    private val bluetoothHandler by lazy { BluetoothPermissionHandler(delegate = bluetoothDelegate) }
+    /**
+     * Returns the notification handler (used by the async-only check path).
+     * Throws if NOTIFICATION was not registered.
+     */
+    private suspend fun notificationHandler(): NotificationPermissionHandler {
+        val handler = handlerFor(AppGrant.NOTIFICATION)
+        check(handler is NotificationPermissionHandler) {
+            "Registered NOTIFICATION handler is not a NotificationPermissionHandler"
+        }
+        return handler
+    }
 
     // ====================================================================
     // PUBLIC API
@@ -125,7 +175,7 @@ actual class PlatformGrantDelegate(
                     if (getMonotonicTimeMillis() - timestamp < STATUS_CACHE_TTL_MS) return@withLock cachedStatus
                 }
             }
-            
+
             // Perform actual status check logic inline
             val status = if (grant is RawPermission) {
                 val iosKey = grant.iosUsageKey
@@ -133,9 +183,10 @@ actual class PlatformGrantDelegate(
                 else if (store.isRawPermissionRequested(grant.identifier)) GrantStatus.DENIED
                 else GrantStatus.NOT_DETERMINED
             } else if ((grant as AppGrant) == AppGrant.NOTIFICATION) {
-                notificationHandler.checkStatusAsync()
+                notificationHandler().checkStatusAsync()
             } else {
-                runOnMain { handlerFor(grant).checkStatus() }
+                val handler = handlerFor(grant)
+                runOnMain { handler.checkStatus() }
             }
 
             mapsMutex.withLock { statusCacheMap[identifier] = status to getMonotonicTimeMillis() }
@@ -157,7 +208,7 @@ actual class PlatformGrantDelegate(
             val results = mutableMapOf<GrantPermission, GrantStatus>()
             grants.forEachIndexed { index, grant ->
                 results[grant] = requestInternal(grant)
-                
+
                 // UX Improvement: Add a small delay between sequential dialogs on iOS.
                 if (index < grants.size - 1) {
                     kotlinx.coroutines.delay(SEQUENTIAL_REQUEST_DELAY_MS)
@@ -204,7 +255,7 @@ actual class PlatformGrantDelegate(
                     GrantLogger.w(TAG, "UIApplication.sharedApplication is not accessible in this context.")
                     return@dispatch_async
                 }
-                
+
                 sharedApp.openURL(
                     url,
                     options = emptyMap<Any?, Any>(),
@@ -227,7 +278,7 @@ actual class PlatformGrantDelegate(
     private suspend fun requestInternal(grant: GrantPermission): GrantStatus {
         mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
 
-        // Since getMutexFor() returns a ReentrantMutex, calling the public checkStatus() 
+        // Since getMutexFor() returns a ReentrantMutex, calling the public checkStatus()
         // here is now safe and will not deadlock.
         val currentStatus = checkStatus(grant)
         if (currentStatus == GrantStatus.GRANTED || currentStatus == GrantStatus.PARTIAL_GRANTED) {
@@ -245,58 +296,19 @@ actual class PlatformGrantDelegate(
                 mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
                 return result
             }
-            
+
             GrantLogger.w(TAG, "RawPermission '${grant.identifier}' on iOS: no generic request API available. " +
                 "Implement a custom IosPermissionHandler for this permission and register it via IosPermissionHandlerRegistry.")
             return GrantStatus.NOT_DETERMINED
         }
 
         val result = when (grant as AppGrant) {
-            AppGrant.NOTIFICATION -> notificationHandler.request()
+            AppGrant.NOTIFICATION -> notificationHandler().request()
             else                  -> handlerFor(grant).request()
         }
 
         mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
         return result
-    }
-
-    // ====================================================================
-    // HANDLER DISPATCH
-    // ====================================================================
-
-    /**
-     * Returns the appropriate [IosPermissionHandler] for the given [AppGrant].
-     *
-     * Note: [AppGrant.NOTIFICATION] is handled separately in [checkStatusInternal]
-     * and [requestInternal] due to its async-only check path.
-     */
-    private fun handlerFor(grant: AppGrant): IosPermissionHandler = when (grant) {
-        AppGrant.CAMERA               -> cameraHandler
-        AppGrant.MICROPHONE           -> microphoneHandler
-
-        AppGrant.GALLERY,
-        AppGrant.STORAGE,
-        AppGrant.GALLERY_IMAGES_ONLY,
-        AppGrant.GALLERY_VIDEO_ONLY   -> photoHandler
-
-        AppGrant.LOCATION             -> locationWhenInUseHandler
-        AppGrant.LOCATION_ALWAYS      -> locationAlwaysHandler
-
-        AppGrant.NOTIFICATION         -> notificationHandler   // unreachable here; handled above
-
-        AppGrant.CONTACTS,
-        AppGrant.READ_CONTACTS        -> contactsHandler
-
-        AppGrant.CALENDAR,
-        AppGrant.READ_CALENDAR        -> calendarHandler
-
-        AppGrant.MOTION               -> motionHandler
-
-        AppGrant.BLUETOOTH,
-        AppGrant.BLUETOOTH_ADVERTISE  -> bluetoothHandler
-
-        AppGrant.SCHEDULE_EXACT_ALARM,
-        AppGrant.NEARBY_WIFI_DEVICES  -> AlwaysGrantedHandler
     }
 
     // ====================================================================
@@ -310,17 +322,4 @@ actual class PlatformGrantDelegate(
     private fun hasInfoPlistKey(key: String): Boolean = hasInfoPlistKey(TAG, key)
 
     actual fun setLauncher(launcher: GrantLauncher) {}
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Singleton handler for permissions that are always granted on iOS
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * A no-op handler for permissions that iOS always grants without a dialog
- * (e.g., [AppGrant.SCHEDULE_EXACT_ALARM]).
- */
-private object AlwaysGrantedHandler : IosPermissionHandler {
-    override fun checkStatus(): GrantStatus = GrantStatus.GRANTED
-    override suspend fun request(): GrantStatus = GrantStatus.GRANTED
 }

--- a/grant-core/src/iosTest/kotlin/dev/brewkits/grant/IosGrantBuilderRegistryTest.kt
+++ b/grant-core/src/iosTest/kotlin/dev/brewkits/grant/IosGrantBuilderRegistryTest.kt
@@ -1,0 +1,97 @@
+package dev.brewkits.grant
+
+import dev.brewkits.grant.impl.PlatformGrantDelegate
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * iOS-specific tests for the registry-driven [PlatformGrantDelegate].
+ *
+ * These tests verify that:
+ * - Permissions registered via the DSL are dispatched correctly.
+ * - Permissions NOT registered raise an actionable error mentioning the
+ *   missing extension function.
+ * - The legacy `PlatformGrantDelegate(store)` constructor still works
+ *   (it auto-registers everything via `registerAll()`).
+ */
+class IosGrantBuilderRegistryTest {
+
+    private val validStatuses = setOf(
+        GrantStatus.GRANTED,
+        GrantStatus.PARTIAL_GRANTED,
+        GrantStatus.DENIED,
+        GrantStatus.DENIED_ALWAYS,
+        GrantStatus.NOT_DETERMINED
+    )
+
+    @Test
+    fun `block form with bluetooth and location yields working manager`() {
+        val manager = GrantFactory.create {
+            bluetooth()
+            location()
+        }
+        assertNotNull(manager)
+    }
+
+    @Test
+    fun `registered permission dispatches without throwing`() = runTest {
+        val manager = GrantFactory.create {
+            scheduleExactAlarm()
+        }
+        // SCHEDULE_EXACT_ALARM is the always-granted handler — safe on simulator.
+        val status = manager.checkStatus(AppGrant.SCHEDULE_EXACT_ALARM)
+        assertEquals(GrantStatus.GRANTED, status)
+    }
+
+    @Test
+    fun `unregistered permission raises actionable error`() = runTest {
+        val manager = GrantFactory.create {
+            // Only register bluetooth; CONTACTS is intentionally absent.
+            bluetooth()
+        }
+
+        val exception = assertFails {
+            manager.checkStatus(AppGrant.CONTACTS)
+        }
+        val message = exception.message ?: ""
+        assertTrue(
+            "CONTACTS" in message,
+            "Error message should mention which permission was missing. Got: $message"
+        )
+        assertTrue(
+            "contacts()" in message || "registerAll" in message,
+            "Error message should suggest the fix (call contacts() or registerAll()). Got: $message"
+        )
+    }
+
+    @Test
+    fun `legacy no-arg constructor still works`() = runTest {
+        // Existing tests/consumers that built the delegate directly continue to work.
+        val delegate = PlatformGrantDelegate(InMemoryGrantStore())
+        val status = delegate.checkStatus(AppGrant.SCHEDULE_EXACT_ALARM)
+        assertEquals(GrantStatus.GRANTED, status)
+    }
+
+    @Test
+    fun `registerAll matches legacy behavior for simulator-safe permissions`() = runTest {
+        val manager = GrantFactory.create { registerAll() }
+        val simulatorSafe = listOf(
+            AppGrant.SCHEDULE_EXACT_ALARM,
+            AppGrant.CAMERA,
+            AppGrant.MICROPHONE,
+            AppGrant.LOCATION,
+            AppGrant.BLUETOOTH
+        )
+        simulatorSafe.forEach { grant ->
+            val status = manager.checkStatus(grant)
+            assertTrue(
+                status in validStatuses,
+                "registerAll() must dispatch ${grant.name} correctly; got $status"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #38.

## TL;DR

`PlatformGrantDelegate.handlerFor()` references every handler class in one exhaustive `when (grant: AppGrant)`. K/N treats those as compile-time references and keeps every handler — and every `import platform.X.*` inside — linked in the release binary, even when the consumer only requests Location/Bluetooth/Notification. Apple's static analyzer then demands `NSCalendarsUsageDescription` / `NSContactsUsageDescription` / `NSMotionUsageDescription` purpose strings, rejecting TestFlight uploads with ITMS-90683.

This PR adds an opt-in DSL — `GrantFactory.create { … }` — where each permission's handler is registered by a per-permission extension function (`location()`, `bluetooth()`, …). Each `actual fun` references only the handlers it needs. If a consumer omits an extension, K/N DCE strips that handler and its `import platform.X.*` from the binary. The legacy no-arg factory is deprecated but still works (registers everything via `registerAll()`).

## Why the v1.3.0 Handler Pattern fix wasn't enough

v1.3.0 isolated each handler's framework imports into its own file. That's necessary but not sufficient: the dispatcher still names every handler property in one `when` expression, so the K/N call-graph walk keeps every handler class reachable. `by lazy` defers _initialization_, not class _reachability_. The Apple scanner only looks at what's linked into the binary, not what executes at runtime.

Proof, from a downstream KMP app on v1.4.1 that only requests `LOCATION` / `LOCATION_ALWAYS` / `BLUETOOTH` / `NOTIFICATION`:

```
$ nm -u ComposeApp.framework/ComposeApp \
    | grep -iE '_OBJC_CLASS_\$_(CMMotion|CMPedometer|EKEvent|EKCalendar|CNContact|CLLocation|CBCentral|UNUserNotification)' \
    | sort -u
_OBJC_CLASS_$_CBCentralManager
_OBJC_CLASS_$_CLLocation
_OBJC_CLASS_$_CLLocationManager
_OBJC_CLASS_$_CMMotionActivityManager     <-- never requested
_OBJC_CLASS_$_CNContactStore              <-- never requested
_OBJC_CLASS_$_EKEventStore                <-- never requested
_OBJC_CLASS_$_UNUserNotificationCenter
```

The bottom three are linked despite no code path in the consuming app referencing them. App Store rejects with three ITMS-90683 errors for the matching purpose strings.

## The fix — opt-in registration

```kotlin
val grantManager = GrantFactory.create {
    location()
    locationAlways()
    bluetooth()
    notification()
    // contacts(), calendar(), motion() not called →
    //   ContactsPermissionHandler / CalendarPermissionHandler / MotionPermissionHandler
    //   are unreachable → K/N strips them → Contacts/EventKit/CoreMotion not linked.
}
```

### How it works

- `GrantBuilder` lives in `commonMain` and accumulates `Map<AppGrant, () -> Any>` of handler factories.
- Per-permission extensions (`location`, `bluetooth`, `contacts`, …) are declared `expect` in commonMain and `actual` per platform.
- On iOS, each `actual fun GrantBuilder.contacts()` references only `ContactsPermissionHandler`. If the consumer never calls `contacts()`, that function is unreachable, the handler class is unreachable, and K/N drops it along with its `import platform.Contacts.*`.
- `PlatformGrantDelegate.handlerFor()` becomes a registry lookup: `factories[grant]?.invoke() ?: error("Permission \$grant not registered. Add \${suggestedExtension(grant)}() to your GrantFactory.create { } block.")`. The error message names the missing extension so failures are actionable.
- On Android, the extensions are no-ops — the Android delegate dispatches through the Activity Result API directly with no per-permission handler classes. The DSL exists for cross-platform API symmetry only; using it has no link-time effect on the APK.

### Critical: the dispatcher must NOT reference every handler from one site

This is the architectural rule that makes DCE work. Any code shape that names every handler class in one site (an exhaustive `when`, a companion `init` block that constructs them all, a `Map` literal with every entry, …) will defeat K/N DCE and put us back where we started. The new dispatcher only ever sees `factories[grant]?.invoke()` — class names come from per-permission `actual fun` calls in consumer-reachable code.

## Backward compatibility

- `GrantFactory.create()` (no-arg) — kept, marked `@Deprecated` with a `ReplaceWith` pointing at the block form. Internally it calls `create(context, store) { registerAll() }`, which references every per-permission extension (so the K/N linker keeps every handler — current behavior preserved exactly).
- `PlatformGrantDelegate(store)` (legacy single-arg constructor) — kept; routes through the same `registerAll()` path so apps that constructed the delegate directly continue to work.
- All existing tests pass without modification (they emit deprecation warnings on the no-arg `create()`, expected).

## Tests

- **8 new common tests** in `GrantBuilderTest` covering:
  - empty block produces empty registry
  - `registerAll()` registers every `AppGrant` (asserts count = `AppGrant.entries.size`)
  - selective registration only adds requested permissions (and explicitly verifies CAMERA/CONTACTS/MOTION/CALENDAR are absent when not registered)
  - multi-grant extensions: `bluetooth()` covers `BLUETOOTH_ADVERTISE`, `contacts()` covers `READ_CONTACTS`, `calendar()` covers `READ_CALENDAR`, `gallery()` covers all 3 gallery variants
- **5 new iOS tests** in `IosGrantBuilderRegistryTest` covering:
  - block-form construction yields a working manager
  - registered permission dispatches without throwing
  - unregistered permission raises an actionable error mentioning both the `AppGrant` name and the suggested extension (`contacts()` / `registerAll`)
  - legacy `PlatformGrantDelegate(store)` constructor still works
  - `registerAll()` dispatches simulator-safe permissions to valid statuses
- **Full suite:** 366 iOS simulator tests, 0 failures, 0 errors, 0 skipped.

## Verification

- `./gradlew :grant-core:compileKotlinIosArm64 :grant-core:compileKotlinIosSimulatorArm64` — clean, warnings unchanged from baseline.
- `./gradlew :grant-core:iosSimulatorArm64Test` — 366 tests pass.
- `./gradlew :grant-core:linkReleaseFrameworkIosArm64` — clean.

The downstream DCE win is observable on a real consuming app — the published library archive itself includes every handler (as it must, since any combination might be opted into by a consumer), but a consumer that calls `create { bluetooth(); location() }` and runs `nm -u <Their.framework>` will no longer see `CMMotionActivityManager` / `CNContactStore` / `EKEventStore`. I'm preparing that downstream verification on the ELogs KMP app and will post the `nm` diff in a follow-up comment once Apple has accepted the resulting TestFlight upload.

## Files changed (10)

- `grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFactory.kt` — new block-form `create`, deprecate no-arg, declare `createPlatformDelegateWithRegistry` expect
- `grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantBuilder.kt` — new `GrantBuilder` class + `registerAll()` + `expect` declarations
- `grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantFactory.ios.kt` — `actual` registry-aware factory
- `grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantBuilder.ios.kt` — `actual` per-permission extensions; only this file references the handler classes
- `grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt` — registry-driven dispatcher, legacy constructor kept
- `grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantFactory.android.kt` — `actual` registry-aware factory (registry ignored on Android)
- `grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantBuilder.android.kt` — `actual` per-permission no-op extensions
- `grant-core/src/commonTest/kotlin/dev/brewkits/grant/GrantBuilderTest.kt` — new
- `grant-core/src/iosTest/kotlin/dev/brewkits/grant/IosGrantBuilderRegistryTest.kt` — new
- `CHANGELOG.md` — `[Unreleased]` entry

## Notes for review

- The `() -> Any` value type on `GrantBuilder.registrations` is intentional — commonMain doesn't depend on iOS-specific `IosPermissionHandler`, and the iOS factory casts on use. Open to suggestions for a cleaner platform-typed registry if you prefer.
- Android's `actual` extensions register a `() -> Any` no-op sentinel rather than skipping registration entirely. This keeps the cross-platform tests in `GrantBuilderTest` working on both platforms (they assert `AppGrant.X in builder.registrations`).
- `suggestedExtension()` in `PlatformGrantDelegate.ios.kt` duplicates the per-permission grouping from `GrantBuilder.ios.kt`. Considered DRYing this into a commonMain map but doing so would re-introduce a single-site reference to every permission category, which is exactly the shape DCE penalizes. The duplication is intentional. Happy to consolidate if you can see a way that doesn't break DCE.
- Did not bump the version number or touch publish scripts — leaving that to you for the release cut.