### PR TITLE
docs: fix broken Quick Start and Demo App links in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Grant is not just another permission library. It is a **production-hardened engine** designed to handle complex edge cases that lead to crashes and hangs in other solutions. Built for professionals who demand absolute reliability.
 
-[**Explore Documentation**](docs/README.md) • [**Quick Start**](#-quick-start) • [**Why Grant?**](#-why-grant) • [**Demo App**](#-demo)
+[**Explore Documentation**](docs/README.md) • [**Quick Start**](docs/getting-started/quick-start.md) • [**Why Grant?**](#-why-grant) • [**Demo App**](docs/demo/DEMO_GUIDE.md)
 
 </div>
 


### PR DESCRIPTION
## Summary

Fixes #47.

The README header nav had two dead anchor links:

| Link | Was | Problem |
|---|---|---|
| **Quick Start** | `#-quick-start` | No "Quick Start" heading exists in the README anymore |
| **Demo App** | `#-demo` | No "Demo" heading exists in the README anymore |

Both now point to the existing docs pages:

- **Quick Start** → `docs/getting-started/quick-start.md` (the target suggested in the issue)
- **Demo App** → `docs/demo/DEMO_GUIDE.md`

The `Explore Documentation` and `Why Grant?` links were already valid and are unchanged.

## Testing

Docs-only change. Verified the target files exist and that no in-page `Quick Start` / `Demo` headings remain (`grep` over README).