### PR TITLE
docs: sync framework-isolation docs with v2.2.0 source

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,16 +201,18 @@ kotlin {
 
 ```swift
 // iOS — AppDelegate / @main entry point
-GrantContacts.shared.initialize()   // if you added grant-contacts
-GrantCalendar.shared.initialize()   // if you added grant-calendar
-GrantMotion.shared.initialize()     // if you added grant-motion
+GrantContacts.shared.initialize()        // if you added grant-contacts
+GrantCalendar.shared.initialize()        // if you added grant-calendar
+GrantMotion.shared.initialize()          // if you added grant-motion
+GrantBluetooth.shared.initialize()       // if you added grant-bluetooth
+GrantLocationAlways.shared.initialize()  // if you added grant-location-always
 ```
 
 > [!IMPORTANT]
 > For projects targeting **Web (JS)** or **Desktop (JVM)**, use an intermediate `mobileMain` source set to avoid linking iOS/Android dependencies on unsupported platforms. [Read the Guide](docs/DEPENDENCY_MANAGEMENT.md).
 
 > [!NOTE]
-> **Migrating from v1.x?** Contacts, Calendar, and Motion permissions are now opt-in modules. Add the corresponding artifact and call `initialize()` on iOS. Android behavior is unchanged — no code changes required on Android. See the [Migration Guide](docs/MIGRATION_GUIDE.md).
+> **Migrating from v1.x?** Contacts, Calendar, Motion, Bluetooth, and background ("always") Location permissions are now opt-in modules. Add the corresponding artifact and call `initialize()` on iOS. Android behavior is unchanged — no code changes required on Android. See the [Migration Guide](docs/MIGRATION_GUIDE.md).
 
 ---
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 # Migration Guide to Grant
 
-**Version:** 2.1.0
-**Last Updated:** May 15, 2026
+**Version:** 2.2.0
+**Last Updated:** June 20, 2026
 
 This guide helps you migrate from previous versions of Grant or other permission libraries.
 
@@ -9,14 +9,66 @@ This guide helps you migrate from previous versions of Grant or other permission
 
 ## 📚 Table of Contents
 
-1. [Upgrading from Grant 1.x to 2.1.0](#upgrading-from-grant-1x-to-200)
-2. [Upgrading from Grant 1.3.x to 1.4.2](#upgrading-from-grant-13x-to-142)
-3. [From moko-permissions](#from-moko-permissions)
-4. [From Google Accompanist](#from-google-accompanist)
-5. [From Custom Implementation](#from-custom-implementation)
-6. [From Native Android APIs](#from-native-android-apis)
-7. [Common Migration Patterns](#common-migration-patterns)
-8. [Troubleshooting](#troubleshooting)
+1. [Upgrading from Grant 2.1.0 to 2.2.0](#upgrading-from-grant-210-to-220)
+2. [Upgrading from Grant 1.x to 2.1.0](#upgrading-from-grant-1x-to-200)
+3. [Upgrading from Grant 1.3.x to 1.4.2](#upgrading-from-grant-13x-to-142)
+4. [From moko-permissions](#from-moko-permissions)
+5. [From Google Accompanist](#from-google-accompanist)
+6. [From Custom Implementation](#from-custom-implementation)
+7. [From Native Android APIs](#from-native-android-apis)
+8. [Common Migration Patterns](#common-migration-patterns)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## 🛡️ Upgrading from Grant 2.1.0 to 2.2.0
+
+### Overview
+
+v2.2.0 (Issue #45) continues the **iOS Framework Isolation** work started in v2.1.0. Two more sensitive paths were moved out of `grant-core` into opt-in modules so apps that don't use them are never flagged by Apple's static scanner:
+
+- **`grant-bluetooth`** — `CoreBluetooth.framework` is no longer linked by `grant-core`, so the `NSBluetoothAlwaysUsageDescription` requirement disappears for apps that don't use Bluetooth.
+- **`grant-location-always`** — the `requestAlwaysAuthorization` (background location) selector moved out of core. `grant-core` now calls **only** `requestWhenInUseAuthorization`. Apps using only foreground location are no longer asked for `NSLocationAlwaysAndWhenInUseUsageDescription`.
+
+**Android is completely unaffected** — no code changes required on Android.
+
+### What Changed?
+
+- **New optional modules**: `grant-bluetooth`, `grant-location-always`. Each links its native iOS framework / selector only when added.
+- **`AppGrant` is unchanged**: `BLUETOOTH`, `BLUETOOTH_ADVERTISE`, and `LOCATION_ALWAYS` are still valid enum values. On iOS they now resolve through the opt-in module's registered handler instead of a built-in one.
+
+### Step-by-Step Upgrade (iOS only)
+
+#### 1. Bump every Grant artifact to `2.2.0`
+
+#### 2. Add the new modules only if you use those permissions
+
+```kotlin
+// shared/build.gradle.kts
+commonMain.dependencies {
+    implementation("dev.brewkits:grant-core:2.2.0")
+    implementation("dev.brewkits:grant-bluetooth:2.2.0")        // only if you use AppGrant.BLUETOOTH / BLUETOOTH_ADVERTISE
+    implementation("dev.brewkits:grant-location-always:2.2.0")  // only if you use AppGrant.LOCATION_ALWAYS (background) on iOS
+}
+```
+
+#### 3. Call `initialize()` once on iOS for each new module you added
+
+```swift
+// Swift
+GrantBluetooth.shared.initialize()
+GrantLocationAlways.shared.initialize()
+```
+
+```kotlin
+// iosMain — call once at app start
+GrantBluetooth.initialize()
+GrantLocationAlways.initialize()
+```
+
+> ⚠️ If you request `BLUETOOTH` / `BLUETOOTH_ADVERTISE` / `LOCATION_ALWAYS` on iOS **without** adding the corresponding module and calling `initialize()`, the handler is not registered: `checkStatus()` and `request()` log a warning and return `NOT_DETERMINED` (no system dialog is shown — it does not hang or crash). On Android these permissions continue to work without any extra module.
+
+#### 4. No changes required for Android
 
 ---
 

--- a/docs/grant-core/ARCHITECTURE.md
+++ b/docs/grant-core/ARCHITECTURE.md
@@ -53,20 +53,27 @@ This document explains the architectural decisions behind KMP Grant library and 
 └──────────────────┘           └──────────────────┘
 ```
 
-## 🍎 iOS Framework Isolation (v2.1.0)
+## 🍎 iOS Framework Isolation (v2.1.0 → v2.2.0)
 
-To avoid App Store rejections due to "unused sensitive permissions", Grant isolates `Contacts.framework`, `EventKit.framework`, and `CoreMotion.framework` into separate Gradle/Maven artifacts. Apps that don't add these optional modules never link these frameworks — Apple's static scanner never requires the corresponding `NSUsageDescription` keys.
+To avoid App Store rejections due to "unused sensitive permissions", Grant isolates the sensitive iOS frameworks into separate Gradle/Maven artifacts. Apps that don't add these optional modules never link these frameworks — Apple's static scanner never requires the corresponding `NSUsageDescription` keys.
 
 ### The Problem
-Kotlin/Native's dead code elimination (DCE) sometimes fails to remove framework linkages if they are referenced in a large, monolithic platform delegate. This causes the App Store static scanner to detect frameworks like `CoreLocation` or `CoreBluetooth` even if your app never requests them.
+Kotlin/Native's dead code elimination (DCE) sometimes fails to remove framework linkages if they are referenced in a large, monolithic platform delegate. This causes the App Store static scanner to detect frameworks like `CoreBluetooth` — or selectors like `requestAlwaysAuthorization` — even if your app never requests them.
 
-### The Solution: Opt-In Modules (v2.1.0)
-As of v2.1.0, the three sensitive frameworks are isolated into their own Gradle modules:
-- `grant-contacts` — links `Contacts.framework` only when added
-- `grant-calendar` — links `EventKit.framework` only when added
-- `grant-motion` — links `CoreMotion.framework` only when added
+### The Solution: Opt-In Modules
+The sensitive frameworks and selectors are isolated into their own Gradle modules:
 
-`CoreLocation`, `CoreBluetooth`, `Photos`, and `AVFoundation` remain in `grant-core` and are weak-linked there. Each optional module also uses `-weak_framework` for defense in depth.
+| Module | What it isolates | Since |
+|---|---|---|
+| `grant-contacts` | `Contacts.framework` | v2.1.0 |
+| `grant-calendar` | `EventKit.framework` | v2.1.0 |
+| `grant-motion` | `CoreMotion.framework` | v2.1.0 |
+| `grant-bluetooth` | `CoreBluetooth.framework` | v2.2.0 |
+| `grant-location-always` | the `requestAlwaysAuthorization` selector (background location) | v2.2.0 |
+
+`CoreLocation` (when-in-use only — `grant-core` calls only `requestWhenInUseAuthorization`), `Photos`, and `AVFoundation` remain in `grant-core` and are weak-linked there. Each optional module also uses `-weak_framework` for defense in depth.
+
+> **Note:** Status-checking in core still maps `kCLAuthorizationStatusAuthorizedAlways → GRANTED`, which is a harmless enum read — Apple's scanner inspects method selectors, not enum value comparisons.
 
 ### Custom Registry
 For permissions not natively supported by the core library, or for developers wanting to override default behavior, `IosPermissionHandlerRegistry` allows runtime registration of custom `IosPermissionHandler` implementations for any `RawPermission` identifier.


### PR DESCRIPTION
## Summary

While reviewing all docs against the latest source, I found three user-facing docs still describing the **v2.1.0** framework-isolation state, even though v2.2.0 (Issue #45, PR #45/#46) moved `CoreBluetooth` into `grant-bluetooth` and the `requestAlwaysAuthorization` selector into `grant-location-always`.

### Fixes

| File | Mismatch | Fix |
|---|---|---|
| `docs/grant-core/ARCHITECTURE.md` | Said `CoreBluetooth` still "remain[s] in grant-core"; only listed the 3 v2.1.0 modules | Updated to a 5-row module table (v2.1.0 + v2.2.0); clarified `CoreLocation` is when-in-use only in core |
| `docs/MIGRATION_GUIDE.md` | No 2.1.0→2.2.0 section; `initialize()` block omitted the two new modules | Added a 2.2.0 upgrade section + header/TOC bump |
| `README.md` | iOS `initialize()` block and v1.x migration note omitted `grant-bluetooth` / `grant-location-always` | Added both |

### Verification

- All 8 modules + version strings confirmed against `settings.gradle.kts` and the module `build.gradle.kts` files (all `2.2.0`).
- The "unregistered module" behavior documented in the migration guide was verified against `grant-core/src/iosMain/.../PlatformGrantDelegate.ios.kt`: `NotRegisteredHandler` logs a warning and returns `NOT_DETERMINED` (it does **not** hang or crash).
- `docs/ios/APPLE_FRAMEWORK_LINKING_ISSUE.md` was already up to date (Section 5 covers v2.2.0) — left unchanged.

Docs-only change.