### PR TITLE
fix(android): open system permission dialog without a registered launcher (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ GrantBluetooth.shared.initialize()       // if you added grant-bluetooth
 GrantLocationAlways.shared.initialize()  // if you added grant-location-always
 ```
 
+**Android — no setup required**: Grant ships a self-contained transparent `Activity`, so `request()` opens the system dialog from anywhere (ViewModel, Repository, etc.) with **zero lifecycle binding**. You do not need to register anything.
+
+> [!TIP]
+> **Optional optimization.** If you prefer to drive the system dialog through your own Compose/Activity `ActivityResultLauncher` (no extra transparent Activity launch), register one once via `grantManager.setLauncher(...)`. When a launcher is registered Grant uses it; otherwise it automatically falls back to the built-in transparent Activity. Both paths show the same system dialog.
+
 > [!IMPORTANT]
 > For projects targeting **Web (JS)** or **Desktop (JVM)**, use an intermediate `mobileMain` source set to avoid linking iOS/Android dependencies on unsupported platforms. [Read the Guide](docs/DEPENDENCY_MANAGEMENT.md).
 

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -208,27 +208,21 @@ actual class PlatformGrantDelegate(
         if (grant is AppGrant) store.setRequested(grant)
         else if (grant is RawPermission) store.markRawPermissionRequested(grant.identifier)
 
-        val deferred = kotlinx.coroutines.CompletableDeferred<GrantRequestActivity.GrantResult>()
-        val launcher = this.launcher ?: run {
-            GrantLogger.e(TAG, "No GrantLauncher registered! Call setLauncher() from your Activity/Fragment.")
-            return GrantStatus.DENIED
-        }
-
-        launcher.launch(androidPermissions) { resultMap ->
-            val allGranted = resultMap.values.all { it }
-            val result = if (allGranted) {
-                GrantRequestActivity.GrantResult.GRANTED
-            } else {
-                GrantRequestActivity.GrantResult.DENIED
+        val launcher = this.launcher
+        if (launcher != null) {
+            val deferred = kotlinx.coroutines.CompletableDeferred<Unit>()
+            launcher.launch(androidPermissions) { _ -> deferred.complete(Unit) }
+            try {
+                withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+            } catch (e: Exception) {
+                GrantLogger.e(TAG, "System dialog timeout or error", e)
             }
-            deferred.complete(result)
-        }
-
-        val result = try {
-            withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
-        } catch (e: Exception) {
-            GrantLogger.e(TAG, "System dialog timeout or error", e)
-            GrantRequestActivity.GrantResult.ERROR
+        } else {
+            // No GrantLauncher registered — fall back to the self-contained transparent
+            // GrantRequestActivity so the system dialog still opens without requiring the
+            // app to bind a launcher to its Activity/Fragment lifecycle (Issue #53).
+            GrantLogger.d(TAG, "No GrantLauncher registered; using GrantRequestActivity fallback.")
+            requestViaActivity(androidPermissions)
         }
 
         // Invalidate cache immediately after system dialog returns
@@ -302,20 +296,20 @@ actual class PlatformGrantDelegate(
 
         if (allAndroidPermissions.isEmpty()) return grants.associateWith { checkStatus(it) }
 
-        val deferred = kotlinx.coroutines.CompletableDeferred<Boolean>()
-        val launcher = this.launcher ?: run {
-            GrantLogger.e(TAG, "No GrantLauncher registered!")
-            return grants.associateWith { GrantStatus.DENIED }
-        }
-
-        launcher.launch(allAndroidPermissions.toList()) { resultMap ->
-            deferred.complete(true)
-        }
-
-        try {
-            withTimeout(60_000) { deferred.await() }
-        } catch (e: Exception) {
-            GrantLogger.e("AndroidGrant", "Multi-request failed", e)
+        val launcher = this.launcher
+        if (launcher != null) {
+            val deferred = kotlinx.coroutines.CompletableDeferred<Boolean>()
+            launcher.launch(allAndroidPermissions.toList()) { _ -> deferred.complete(true) }
+            try {
+                withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+            } catch (e: Exception) {
+                GrantLogger.e("AndroidGrant", "Multi-request failed", e)
+            }
+        } else {
+            // No GrantLauncher registered — fall back to the self-contained transparent
+            // GrantRequestActivity so the system dialog still opens without lifecycle binding (Issue #53).
+            GrantLogger.d(TAG, "No GrantLauncher registered; using GrantRequestActivity fallback for multi-request.")
+            requestViaActivity(allAndroidPermissions.toList())
         }
 
         mapsMutex.withLock {
@@ -333,6 +327,27 @@ actual class PlatformGrantDelegate(
                     grant to finalStatus 
                 }
             }.awaitAll().toMap()
+        }
+    }
+
+    /**
+     * Fallback request path used when no [GrantLauncher] has been registered via [setLauncher].
+     *
+     * Launches the self-contained transparent [GrantRequestActivity], which owns its own
+     * [androidx.activity.result.ActivityResultLauncher], so the system permission dialog opens
+     * from any context (ViewModel, Repository, etc.) without the app having to bind a launcher
+     * to an Activity/Fragment lifecycle. Suspends until the dialog resolves; the caller re-reads
+     * the real status via [checkStatus] afterwards. (Issue #53)
+     */
+    private suspend fun requestViaActivity(androidPermissions: List<String>) {
+        val requestId = GrantRequestActivity.requestGrants(context, androidPermissions)
+        val deferred = GrantRequestActivity.getResultDeferred(requestId) ?: return
+        try {
+            withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+        } catch (e: Exception) {
+            GrantLogger.e(TAG, "GrantRequestActivity fallback timeout or error", e)
+        } finally {
+            GrantRequestActivity.cleanup(requestId)
         }
     }
 

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue53NoLauncherFallbackTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue53NoLauncherFallbackTest.kt
@@ -1,0 +1,144 @@
+package dev.brewkits.grant.impl
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantStatus
+import dev.brewkits.grant.InMemoryGrantStore
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for Issue #53 — "El diálogo de permisos del sistema de Android no se abre"
+ * (the Android system permission dialog does not open).
+ *
+ * Background
+ * ----------
+ * Since v1.4.3 (commit 7f5257c) the main Android `request()` path was rewired to require a
+ * [dev.brewkits.grant.GrantLauncher] registered via `setLauncher()`. When no launcher was
+ * registered, `requestInternal()` logged an error and returned [GrantStatus.DENIED] **without
+ * ever showing the system dialog**. iOS was unaffected (no launcher concept), which is exactly
+ * the "only Android" symptom the reporter saw on 2.1.0 and 2.2.0.
+ *
+ * This contradicted the library's "No Lifecycle Binding" promise: the self-contained transparent
+ * [GrantRequestActivity] — declared in grant-core's manifest — could already open the dialog from
+ * any context. The fix restores that fallback: when no launcher is set, `request()` routes through
+ * [GrantRequestActivity.requestGrants].
+ *
+ * What this test pins down
+ * ------------------------
+ * With **no** launcher registered, `delegate.request(CAMERA)` must invoke
+ * [GrantRequestActivity.requestGrants] exactly once (i.e. it actually tries to open the dialog),
+ * rather than short-circuiting to DENIED.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU], manifest = Config.NONE)
+class Issue53NoLauncherFallbackTest {
+
+    private lateinit var context: Context
+    private lateinit var store: InMemoryGrantStore
+    private lateinit var delegate: PlatformGrantDelegate
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        store = InMemoryGrantStore()
+        delegate = PlatformGrantDelegate(context, store)
+
+        // The request path filters permissions through ManifestValidator.isPermissionDeclared,
+        // so the permission must be declared in the (Robolectric) package manifest.
+        val pm = shadowOf(context.packageManager)
+        val packageInfo = android.content.pm.PackageInfo().apply {
+            packageName = context.packageName
+            requestedPermissions = arrayOf(Manifest.permission.CAMERA)
+        }
+        pm.installPackage(packageInfo)
+
+        // CAMERA not yet granted → checkStatus is NOT_DETERMINED → request must show the dialog.
+        shadowOf(context as Application).denyPermissions(Manifest.permission.CAMERA)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(GrantRequestActivity.Companion)
+    }
+
+    @Test
+    fun `request without a registered launcher falls back to GrantRequestActivity`() = runBlocking {
+        // Note: setLauncher is intentionally NOT called — this reproduces Issue #53.
+        val fallbackCallCount = AtomicInteger(0)
+
+        mockkObject(GrantRequestActivity.Companion)
+        every { GrantRequestActivity.requestGrants(any(), any()) } answers {
+            fallbackCallCount.incrementAndGet()
+            "issue53-request-id"
+        }
+        // Complete immediately so the suspending await() does not block the test.
+        every { GrantRequestActivity.getResultDeferred(any()) } answers {
+            CompletableDeferred<GrantRequestActivity.GrantResult>().apply {
+                complete(GrantRequestActivity.GrantResult.DENIED)
+            }
+        }
+        every { GrantRequestActivity.cleanup(any()) } returns Unit
+
+        val status = delegate.request(AppGrant.CAMERA)
+
+        assertEquals(
+            1,
+            fallbackCallCount.get(),
+            "With no launcher registered, request() must fall back to GrantRequestActivity " +
+                "(open the dialog) instead of silently returning DENIED. Got ${fallbackCallCount.get()} calls."
+        )
+        // CAMERA stayed denied in the shadow, so the resolved status is DENIED — but crucially the
+        // dialog was attempted, which is the whole point of Issue #53.
+        assertEquals(GrantStatus.DENIED, status)
+    }
+
+    @Test
+    fun `multi-request without a registered launcher falls back to GrantRequestActivity`() = runBlocking {
+        val pm = shadowOf(context.packageManager)
+        val packageInfo = android.content.pm.PackageInfo().apply {
+            packageName = context.packageName
+            requestedPermissions = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+        }
+        pm.installPackage(packageInfo)
+        shadowOf(context as Application).denyPermissions(Manifest.permission.RECORD_AUDIO)
+
+        val fallbackCallCount = AtomicInteger(0)
+
+        mockkObject(GrantRequestActivity.Companion)
+        every { GrantRequestActivity.requestGrants(any(), any()) } answers {
+            fallbackCallCount.incrementAndGet()
+            "issue53-multi-id"
+        }
+        every { GrantRequestActivity.getResultDeferred(any()) } answers {
+            CompletableDeferred<GrantRequestActivity.GrantResult>().apply {
+                complete(GrantRequestActivity.GrantResult.DENIED)
+            }
+        }
+        every { GrantRequestActivity.cleanup(any()) } returns Unit
+
+        delegate.request(listOf(AppGrant.CAMERA, AppGrant.MICROPHONE))
+
+        assertEquals(
+            1,
+            fallbackCallCount.get(),
+            "Batch request with no launcher must fall back to a single GrantRequestActivity launch."
+        )
+    }
+}


### PR DESCRIPTION
Fixes #53.

## Problem

On Android the system permission dialog never opened; iOS worked fine. Reported on v2.1.0 and v2.2.0.

Since **v1.4.3** (commit 7f5257c) the Android `request()` path was rewired to require a `GrantLauncher` registered via `setLauncher()`. When no launcher was registered, `requestInternal()` / `requestMultipleInternal()` logged an error and returned `GrantStatus.DENIED` **without ever showing the system dialog**. iOS has no launcher concept, which is exactly the "only Android" symptom the reporter saw.

This also broke the library's documented **"No Lifecycle Binding"** promise, and `setLauncher` was never mentioned in the README/docs — so anyone following the README got a silently-broken Android.

## Fix

When no launcher is registered, fall back to the self-contained transparent `GrantRequestActivity` — which is already shipped in `grant-core`'s manifest and already used by the `LOCATION_ALWAYS` 2-step flow — so the dialog opens from any context (ViewModel, Repository, etc.) without lifecycle binding.

- `setLauncher()` remains an **optional optimization**: when a launcher is registered Grant uses it; otherwise it auto-falls back to the transparent Activity. Both paths show the same system dialog.
- Aligned the multi-request timeout with the single-request path (5 min, was 60s).
- Documented the Android behavior + `setLauncher()` in the README Installation section.

## Compatibility

- **Apps that already call `setLauncher()`** (e.g. the demo via `BindGrantsController`): behavior unchanged — only removed an unused local `result` variable.
- **iOS / commonMain**: untouched. The change is entirely in `androidMain`.
- **Compose (`GrantHandler` / `GrantDialog`)**: improved. Previously a Compose app that used `GrantDialog` but never called `setLauncher` would silently get `DENIED` and jump straight to the rationale/settings dialog without the user ever seeing the OS prompt. Now the OS dialog opens and the state machine transitions on the real status.

## Tests

- New regression test `Issue53NoLauncherFallbackTest` (Robolectric + MockK): with no launcher registered, both `request()` and `request(list)` must route through `GrantRequestActivity.requestGrants` exactly once instead of returning `DENIED`.
- Full `:grant-core:testDebugUnitTest` green.