### PR TITLE
fix(android): in-session DENIED to DENIED_ALWAYS shows settings guide not rationale (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2.2.3] - 2026-06-30
+
+### 🐛 Fixed
+
+- **Android: settings guide shown as rationale again after a permanent denial, within the same session ([#55](https://github.com/brewkits/Grant/issues/55) follow-up)**
+  After a permission was permanently denied, dismissing the settings guide and requesting again re-showed the **rationale** dialog instead of the **settings** guide — but only in-session; an app restart behaved correctly. `checkStatus()` short-circuited on the in-memory status cache before consulting the OS-persisted `shouldShowRequestPermissionRationale()` flag, so the second (permanent) denial was masked by the first denial's cached `DENIED` and never became `DENIED_ALWAYS` until the cache was cleared on process death. The OS rationale flag is now consulted first — matching the `RawPermission` and `LOCATION_ALWAYS` branches — so the `DENIED → DENIED_ALWAYS` transition is detected immediately. Verified on a physical Pixel 6 Pro (Android 16); iOS (iPhone XS Max, iOS 18.7.9) is unaffected by design, since it reads the live OS status and has no rationale step.
+
+---
+
 ## [2.2.2] - 2026-06-27
 
 ### 🐛 Fixed

--- a/create-grant-maven-bundle-auto.sh
+++ b/create-grant-maven-bundle-auto.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-VERSION="2.2.2"
+VERSION="2.2.3"
 GROUP_PATH="dev/brewkits"
 BUNDLE_NAME="grant-v${VERSION}-bundle.jar"
 OUTPUT_DIR="maven-central-artifacts/v${VERSION}"

--- a/docs/architecture/grant-store.md
+++ b/docs/architecture/grant-store.md
@@ -133,7 +133,7 @@ fun `in-memory store resets on recreation`() {
 }
 ```
 
-See `SharedPreferencesGrantStoreTest` and `Issue55PermanentDenialAfterRestartTest` in `grant-core/src/androidUnitTest` for the full coverage, including the regression that pins down `DENIED_ALWAYS` (not `NOT_DETERMINED`) after a permanent denial and restart.
+See `SharedPreferencesGrantStoreTest`, `Issue55PermanentDenialAfterRestartTest`, and `Issue55InSessionDeniedAlwaysTest` in `grant-core/src/androidUnitTest` for the full coverage — including the regression that pins down `DENIED_ALWAYS` (not `NOT_DETERMINED`) after a permanent denial and restart, and the one that pins down the *in-session* `DENIED → DENIED_ALWAYS` transition (the OS rationale flag must be consulted before the in-memory status cache, or a second denial is masked by the first denial's cached `DENIED`).
 
 ---
 

--- a/grant-bluetooth/build.gradle.kts
+++ b/grant-bluetooth/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-bluetooth/build.gradle.kts
+++ b/grant-bluetooth/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Bluetooth")

--- a/grant-calendar/build.gradle.kts
+++ b/grant-calendar/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-calendar/build.gradle.kts
+++ b/grant-calendar/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Calendar")

--- a/grant-compose/build.gradle.kts
+++ b/grant-compose/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-compose/build.gradle.kts
+++ b/grant-compose/build.gradle.kts
@@ -105,7 +105,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Compose")

--- a/grant-contacts/build.gradle.kts
+++ b/grant-contacts/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-contacts/build.gradle.kts
+++ b/grant-contacts/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Contacts")

--- a/grant-core-koin/build.gradle.kts
+++ b/grant-core-koin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-core-koin/build.gradle.kts
+++ b/grant-core-koin/build.gradle.kts
@@ -79,7 +79,7 @@ repositories {
 publications.configureEach {
     (this as? MavenPublication)?.let {
         groupId = "dev.brewkits"
-        version = "2.2.2"
+        version = "2.2.3"
 
         pom {
             name.set("KMP Grant Koin")

--- a/grant-core/build.gradle.kts
+++ b/grant-core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-core/build.gradle.kts
+++ b/grant-core/build.gradle.kts
@@ -129,7 +129,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant")

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -189,21 +189,26 @@ actual class PlatformGrantDelegate(
                         else if ((appGrant == AppGrant.GALLERY || appGrant == AppGrant.GALLERY_IMAGES_ONLY || appGrant == AppGrant.GALLERY_VIDEO_ONLY) && isPartialGalleryAccessGranted()) {
                             GrantStatus.PARTIAL_GRANTED
                         } else {
-                            val storedStatus = store.getStatus(appGrant)
-                            if (storedStatus == GrantStatus.DENIED || storedStatus == GrantStatus.DENIED_ALWAYS) {
-                                storedStatus
-                            } else {
-                                // shouldShowRequestPermissionRationale() is OS-persisted and survives
-                                // process death, unlike store.isRequestedBefore(). Check it first so a
-                                // soft denial is still detected after an app restart (Issue #55).
-                                val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
-                                val anyCanShowRationale = activeActivity != null &&
-                                    androidGrants.any { activeActivity.shouldShowRequestPermissionRationale(it) }
-                                when {
-                                    anyCanShowRationale -> GrantStatus.DENIED
-                                    store.isRequestedBefore(appGrant) -> if (activeActivity == null) GrantStatus.DENIED else GrantStatus.DENIED_ALWAYS
-                                    else -> GrantStatus.NOT_DETERMINED
-                                }
+                            // shouldShowRequestPermissionRationale() is the OS source of truth for the
+                            // *live* DENIED vs DENIED_ALWAYS distinction, and it survives process death
+                            // unlike the in-memory status cache. Consult it FIRST so an in-session
+                            // transition (user denies a second time → permanent) is detected immediately
+                            // instead of being masked by a stale stored DENIED (Issue #55 follow-up).
+                            // Falling back to store.getStatus() before this check left checkStatus()
+                            // stuck on the first denial's DENIED for the rest of the process, so the
+                            // settings guide only appeared after a restart.
+                            val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
+                            val anyCanShowRationale = activeActivity != null &&
+                                androidGrants.any { activeActivity.shouldShowRequestPermissionRationale(it) }
+                            when {
+                                anyCanShowRationale -> GrantStatus.DENIED
+                                store.isRequestedBefore(appGrant) ->
+                                    // Requested before and the OS won't show a rationale → permanently
+                                    // denied. With no Activity to consult, fall back to the last known
+                                    // stored status (or DENIED, which keeps the rationale path open).
+                                    if (activeActivity == null) store.getStatus(appGrant) ?: GrantStatus.DENIED
+                                    else GrantStatus.DENIED_ALWAYS
+                                else -> store.getStatus(appGrant) ?: GrantStatus.NOT_DETERMINED
                             }
                         }
                     }

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -190,25 +190,23 @@ actual class PlatformGrantDelegate(
                             GrantStatus.PARTIAL_GRANTED
                         } else {
                             // shouldShowRequestPermissionRationale() is the OS source of truth for the
-                            // *live* DENIED vs DENIED_ALWAYS distinction, and it survives process death
-                            // unlike the in-memory status cache. Consult it FIRST so an in-session
-                            // transition (user denies a second time → permanent) is detected immediately
-                            // instead of being masked by a stale stored DENIED (Issue #55 follow-up).
-                            // Falling back to store.getStatus() before this check left checkStatus()
-                            // stuck on the first denial's DENIED for the rest of the process, so the
-                            // settings guide only appeared after a restart.
+                            // live DENIED vs DENIED_ALWAYS distinction. Consult it FIRST so an in-session
+                            // second denial is seen as permanent immediately, not masked by a stale
+                            // stored DENIED (Issue #55 follow-up). Mirrors the RawPermission/LOCATION_ALWAYS branches.
                             val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
                             val anyCanShowRationale = activeActivity != null &&
                                 androidGrants.any { activeActivity.shouldShowRequestPermissionRationale(it) }
                             when {
                                 anyCanShowRationale -> GrantStatus.DENIED
                                 store.isRequestedBefore(appGrant) ->
-                                    // Requested before and the OS won't show a rationale → permanently
-                                    // denied. With no Activity to consult, fall back to the last known
-                                    // stored status (or DENIED, which keeps the rationale path open).
+                                    // Requested before and no rationale → permanently denied. With no
+                                    // Activity to confirm, fall back to the last stored status (or DENIED,
+                                    // which keeps the rationale path open).
                                     if (activeActivity == null) store.getStatus(appGrant) ?: GrantStatus.DENIED
                                     else GrantStatus.DENIED_ALWAYS
-                                else -> store.getStatus(appGrant) ?: GrantStatus.NOT_DETERMINED
+                                // Never requested → getStatus() is always null here (setStatus only ever
+                                // follows setRequested), so this is simply NOT_DETERMINED.
+                                else -> GrantStatus.NOT_DETERMINED
                             }
                         }
                     }

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue53NoLauncherFallbackTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue53NoLauncherFallbackTest.kt
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 
 /**
- * Regression test for Issue #53 — "El diálogo de permisos del sistema de Android no se abre"
- * (the Android system permission dialog does not open).
+ * Regression test for Issue #53 — "the Android system permission dialog does not open".
  *
  * Background
  * ----------

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55InSessionDeniedAlwaysTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55InSessionDeniedAlwaysTest.kt
@@ -1,0 +1,120 @@
+package dev.brewkits.grant.impl
+
+import android.Manifest
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantStatus
+import dev.brewkits.grant.InMemoryGrantStore
+import dev.brewkits.grant.PlatformConfig
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for the Issue #55 follow-up reported on the issue thread:
+ * after a *second* denial the settings guide never appeared — the rationale dialog
+ * was shown again instead — and the flow only behaved correctly after an app restart.
+ *
+ * Root cause
+ * ----------
+ * The general `AppGrant` branch of [PlatformGrantDelegate.checkStatus] short-circuited
+ * on the in-memory `store.getStatus()` value *before* consulting the OS-persisted
+ * `shouldShowRequestPermissionRationale()` flag:
+ *
+ * ```
+ * val storedStatus = store.getStatus(appGrant)
+ * if (storedStatus == DENIED || storedStatus == DENIED_ALWAYS) storedStatus
+ * else { /* rationale check */ }
+ * ```
+ *
+ * The first denial cached `DENIED` in [InMemoryGrantStore]. When the user then denied a
+ * second time — at which point Android flips `shouldShowRequestPermissionRationale()` to
+ * `false` (permanent denial) — `checkStatus()` returned the stale cached `DENIED` and
+ * never observed the permanent denial, so [dev.brewkits.grant.GrantHandler] kept treating
+ * it as a soft denial and re-showed the rationale.
+ *
+ * Because `store.getStatus()` is in-memory only (status is session state — see
+ * [dev.brewkits.grant.SharedPreferencesGrantStore]), a process restart cleared the stale
+ * `DENIED` and the OS rationale flag was consulted again — which is exactly why the
+ * reporter saw the correct behavior *only after restart*.
+ *
+ * The fix consults the OS rationale flag first, so the in-session
+ * `DENIED → DENIED_ALWAYS` transition is detected without a restart.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class Issue55InSessionDeniedAlwaysTest {
+
+    private lateinit var context: Context
+    private lateinit var store: InMemoryGrantStore
+    private lateinit var delegate: PlatformGrantDelegate
+    private lateinit var activity: Activity
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        store = InMemoryGrantStore()
+        delegate = PlatformGrantDelegate(context, store)
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        PlatformConfig.activity = activity
+    }
+
+    @After
+    fun tearDown() {
+        PlatformConfig.activity = null
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `second denial transitions DENIED to DENIED_ALWAYS in the same session`() = runBlocking {
+        shadowOf(context as Application).denyPermissions(Manifest.permission.CAMERA)
+
+        // Simulate the state right after a SECOND denial within the same process:
+        // - the first denial recorded the request and cached DENIED in the store,
+        // - the second denial flipped the OS rationale flag off (permanent denial).
+        // The stale cached DENIED must NOT mask this; checkStatus must report DENIED_ALWAYS
+        // without requiring a process restart. (The old short-circuit returned the cached
+        // DENIED here, which is the bug.)
+        store.setRequested(AppGrant.CAMERA)
+        store.setStatus(AppGrant.CAMERA, GrantStatus.DENIED)
+        shadowOf(context.packageManager).setShouldShowRequestPermissionRationale(Manifest.permission.CAMERA, false)
+
+        assertEquals(GrantStatus.DENIED_ALWAYS, delegate.checkStatus(AppGrant.CAMERA))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `soft denial still reports DENIED while OS allows a rationale even with cached DENIED`() = runBlocking {
+        shadowOf(context as Application).denyPermissions(Manifest.permission.CAMERA)
+        shadowOf(context.packageManager).setShouldShowRequestPermissionRationale(Manifest.permission.CAMERA, true)
+        store.setRequested(AppGrant.CAMERA)
+        store.setStatus(AppGrant.CAMERA, GrantStatus.DENIED)
+
+        assertEquals(GrantStatus.DENIED, delegate.checkStatus(AppGrant.CAMERA))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `no Activity falls back to cached status so DENIED_ALWAYS is not downgraded`() = runBlocking {
+        shadowOf(context as Application).denyPermissions(Manifest.permission.CAMERA)
+        store.setRequested(AppGrant.CAMERA)
+        store.setStatus(AppGrant.CAMERA, GrantStatus.DENIED_ALWAYS)
+
+        // Without an Activity the OS rationale flag cannot be consulted; the last known
+        // stored status is the best available signal.
+        PlatformConfig.activity = null
+
+        assertEquals(GrantStatus.DENIED_ALWAYS, delegate.checkStatus(AppGrant.CAMERA))
+    }
+}

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55InSessionDeniedAlwaysTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55InSessionDeniedAlwaysTest.kt
@@ -117,4 +117,18 @@ class Issue55InSessionDeniedAlwaysTest {
 
         assertEquals(GrantStatus.DENIED_ALWAYS, delegate.checkStatus(AppGrant.CAMERA))
     }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `no Activity and no stored status falls back to DENIED to keep the rationale path open`() = runBlocking {
+        shadowOf(context as Application).denyPermissions(Manifest.permission.CAMERA)
+        // Requested before, but no status was ever cached (e.g. process death lost the
+        // in-memory status while the persisted request-history flag survived).
+        store.setRequested(AppGrant.CAMERA)
+        PlatformConfig.activity = null
+
+        // No Activity to consult the rationale flag and no cached status → DENIED (not
+        // DENIED_ALWAYS), so the rationale can still be shown once an Activity is available.
+        assertEquals(GrantStatus.DENIED, delegate.checkStatus(AppGrant.CAMERA))
+    }
 }

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55RationaleReappearsRegressionTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/Issue55RationaleReappearsRegressionTest.kt
@@ -1,0 +1,114 @@
+package dev.brewkits.grant.impl
+
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantHandler
+import dev.brewkits.grant.GrantLauncher
+import dev.brewkits.grant.GrantManager
+import dev.brewkits.grant.GrantPermission
+import dev.brewkits.grant.GrantStatus
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end regression test for the Issue #55 follow-up reported on the thread: after a
+ * permission is permanently denied, the **rationale** dialog reappeared instead of the
+ * **settings** guide — but only in-session; an app restart behaved correctly.
+ *
+ * Reproduced root cause (verified by driving the real [GrantHandler]):
+ * 1. The user denies twice through the rationale flow → the settings guide shows.
+ * 2. The user dismisses the settings dialog (e.g. to retry via the screen's button) →
+ *    [GrantHandler.onDismiss] resets `hasShownRationaleDialog` to false.
+ * 3. On the next request, [PlatformGrantDelegate.checkStatus] returned a stale in-memory
+ *    `DENIED` instead of `DENIED_ALWAYS` (the in-memory status cache masked the OS rationale
+ *    flag), so [GrantHandler] treated it as a fresh soft denial and re-showed the rationale.
+ *
+ * A process restart cleared the in-memory cache while the persisted "requested before" flag
+ * survived, so `checkStatus()` then correctly derived `DENIED_ALWAYS` — which is exactly why
+ * the reporter saw it work only after restart.
+ *
+ * The delegate fix consults the OS rationale flag before the in-memory cache, so the
+ * permanent denial is observed in-session. This test drives the full reporter flow through
+ * [GrantHandler] against a fake that faithfully mirrors the Android delegate state machine
+ * and asserts the settings guide — not the rationale — is shown on the final request.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue55RationaleReappearsRegressionTest {
+
+    /**
+     * Faithfully mirrors [PlatformGrantDelegate]'s general AppGrant `checkStatus`/`requestInternal`
+     * behavior with the fix applied: the OS rationale flag is consulted before the in-memory
+     * status cache. `isRequestedBefore` is persisted; `storedStatus` is in-memory only.
+     */
+    private class FakeAndroidDelegate : GrantManager {
+        private var osRationale = false
+        private var requested = false
+        private var storedStatus: GrantStatus? = null
+        private var denialCount = 0
+
+        private fun compute(): GrantStatus = when {
+            osRationale -> GrantStatus.DENIED
+            requested -> GrantStatus.DENIED_ALWAYS
+            else -> storedStatus ?: GrantStatus.NOT_DETERMINED
+        }
+
+        override suspend fun checkStatus(grant: GrantPermission): GrantStatus = compute()
+
+        override suspend fun request(grant: GrantPermission): GrantStatus {
+            requested = true
+            // The user denies; the OS only shows a prompt until the permission goes permanent.
+            if (denialCount < 2) {
+                denialCount++
+                osRationale = (denialCount == 1) // true after 1st denial, false (permanent) after 2nd
+            }
+            return compute().also { if (it != GrantStatus.GRANTED) storedStatus = it }
+        }
+
+        override suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> =
+            grants.associateWith { request(it) }
+
+        override fun openSettings() {}
+        override fun setLauncher(launcher: GrantLauncher) {}
+    }
+
+    @Test
+    fun `settings guide stays after dismiss when permanently denied - rationale does not reappear`() {
+        val scope = TestScope(StandardTestDispatcher())
+        scope.runTest {
+            val handler = GrantHandler(FakeAndroidDelegate(), AppGrant.CAMERA, this)
+
+            // First request → user denies (silent; user must re-initiate).
+            handler.request {}; advanceUntilIdle()
+            assertFalse(handler.state.value.isVisible, "first denial should not show a dialog")
+
+            // Second request → rationale dialog.
+            handler.request {}; advanceUntilIdle()
+            assertTrue(handler.state.value.showRationale, "second request should show the rationale")
+
+            // Confirm rationale → user denies a second time (now permanent) → settings guide.
+            handler.onRationaleConfirmed(); advanceUntilIdle()
+            assertTrue(handler.state.value.showSettingsGuide, "second denial should show the settings guide")
+
+            // User dismisses the settings dialog (resets hasShownRationaleDialog).
+            handler.onDismiss(); advanceUntilIdle()
+            assertFalse(handler.state.value.isVisible, "dismiss should hide all dialogs")
+
+            // Next request: permission is permanently denied → settings guide MUST reappear,
+            // NOT the rationale (the bug). This is the user-visible assertion for Issue #55.
+            handler.request {}; advanceUntilIdle()
+            assertFalse(
+                handler.state.value.showRationale,
+                "rationale must NOT reappear once the permission is permanently denied"
+            )
+            assertTrue(
+                handler.state.value.showSettingsGuide,
+                "settings guide must be shown for a permanently-denied permission"
+            )
+        }
+    }
+}

--- a/grant-location-always/build.gradle.kts
+++ b/grant-location-always/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-location-always/build.gradle.kts
+++ b/grant-location-always/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Location Always")

--- a/grant-motion/build.gradle.kts
+++ b/grant-motion/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.2"
+version = "2.2.3"
 
 kotlin {
     androidTarget {

--- a/grant-motion/build.gradle.kts
+++ b/grant-motion/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.2"
+            version = "2.2.3"
 
             pom {
                 name.set("KMP Grant Motion")


### PR DESCRIPTION
## Problem (Issue #55 follow-up)

Reported on the #55 thread: after a permission is **permanently** denied, the Android flow re-shows the **rationale** dialog instead of the **settings** guide — but only in-session; an app restart behaves correctly.

Exact sequence (from the reporter):
1. Deny twice through the rationale flow → settings guide shows ✅
2. Dismiss the settings dialog (to retry via the screen's button)
3. Tap request again → **rationale reappears** ❌ (expected: settings guide)
4. After an app restart, the flow is correct

## Root cause (Android-only)

In the general `AppGrant` branch of `PlatformGrantDelegate.checkStatus()`, the in-memory `store.getStatus()` value was consulted **before** the OS rationale flag:

```kotlin
val storedStatus = store.getStatus(appGrant)
if (storedStatus == DENIED || storedStatus == DENIED_ALWAYS) storedStatus   // stale short-circuit
else { /* shouldShowRequestPermissionRationale() check */ }
```

The first denial caches `DENIED`. The second (permanent) denial — at which point Android flips `shouldShowRequestPermissionRationale()` to `false` — is **masked** by that stale cached `DENIED`, so `checkStatus()` never reports `DENIED_ALWAYS` in-session.

Then `GrantHandler.onDismiss()` resets `hasShownRationaleDialog = false`, so the next request hits the `DENIED` branch with `isFirstRequest = false` + `hasShownRationaleDialog = false` → the rationale is shown again.

The status cache is **in-memory only** (`SharedPreferencesGrantStore` persists only request-history flags, not status), while `isRequestedBefore` is persisted — so a restart clears the stale `DENIED` and the flow recovers. That's exactly why it only failed in-session.

## Fix

Remove the stale short-circuit; consult `shouldShowRequestPermissionRationale()` first (mirroring the already-correct `RawPermission` and `LOCATION_ALWAYS` branches), and fall back to the stored status only when no Activity is available to consult it.

## Tests

- `Issue55InSessionDeniedAlwaysTest` — delegate-level regression. Verified to fail on the old code and pass on the new (true regression guard).
- `Issue55RationaleReappearsRegressionTest` — drives the real `GrantHandler` through the reporter's full sequence (deny → rationale → deny → settings → dismiss → request) and asserts the settings guide reappears, not the rationale.
- Full `:grant-core:testDebugUnitTest` green; iOS simulator suite green.

## Real-device verification

- **Pixel 6 Pro (Android 16)** — drove the full flow on-device: deny → rationale → deny → settings → **dismiss** → request → **settings guide** (not rationale). Bug fixed in-session.
- **iPhone XS Max (iOS 18.7.9)** — confirmed the bug is structurally impossible on iOS: `checkStatus()` reads live OS status every call (no stale short-circuit) and `isRationaleSupported = false` routes `DENIED` straight to the settings guide, so no rationale dialog exists in the iOS flow. Deny → "Open Settings"; re-request after dismiss → "Open Settings" again.

## Scope

Audited every `checkStatus()` branch: the general `AppGrant` branch was the only one with the stale-status short-circuit. `RawPermission`, `LOCATION_ALWAYS`, the special-access overrides (`SCHEDULE_EXACT_ALARM`, pre-33 `NOTIFICATION`), and the entire iOS path are unaffected.
