### PR TITLE
fix: requestSuspend no-host hang + Android 14 gallery full-access misclassification (2.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2.2.4] - 2026-07-09
+
+### 🐛 Fixed
+
+- **`requestSuspend()` suspended forever when no dialog host was attached**
+  On a DENIED / DENIED_ALWAYS grant, the `StateBased` flow raises rationale / settings-guide
+  dialog state and parks until the dialog host (`GrantDialog` or a custom renderer of
+  `GrantHandler.state`) resumes it. When the app rendered no dialog for that handler — e.g. a
+  headless `requestSuspend()` pre-check before a screen loads — nothing could ever resume the
+  flow and the caller suspended **forever** (real-world case: it silently wedged a consuming
+  app's gallery on its loading skeleton). `requestSuspend` now detects "parked on a dialog
+  with no collector attached to `state`", clears the unrenderable dialog state (mirroring
+  `onDismiss`, including the rationale memory), and completes with the current status. The
+  callback-based `request()` flow is unchanged — raising dialog state without a live collector
+  remains a supported pattern there. Regression: `RequestSuspendNoHostTest`.
+
+- **Android 14+: fully-granted gallery misreported as `DENIED_ALWAYS`**
+  `GALLERY.toAndroidGrants()` includes `READ_MEDIA_VISUAL_USER_SELECTED` on API 34+ so the
+  system dialog offers "Select photos" — but `checkStatus()` also counted it when judging
+  full access (`all { granted }`). The OS can grant `READ_MEDIA_IMAGES` + `READ_MEDIA_VIDEO`
+  while leaving `USER_SELECTED` denied (ADB `pm grant`, MDM policy, permission auto-reset
+  edge states); that fully-usable state failed the all-granted check, and with the grant
+  already in the request history it escalated to `DENIED_ALWAYS`. Full access is now judged
+  on the required permissions only (`toRequiredAndroidGrants()`); `USER_SELECTED` alone still
+  reports `PARTIAL_GRANTED`. Regression: `PlatformGrantDelegateGalleryFullAccessTest`.
+
+---
+
 ## [2.2.3] - 2026-06-30
 
 ### 🐛 Fixed

--- a/create-grant-maven-bundle-auto.sh
+++ b/create-grant-maven-bundle-auto.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-VERSION="2.2.3"
+VERSION="2.2.4"
 GROUP_PATH="dev/brewkits"
 BUNDLE_NAME="grant-v${VERSION}-bundle.jar"
 OUTPUT_DIR="maven-central-artifacts/v${VERSION}"

--- a/grant-bluetooth/build.gradle.kts
+++ b/grant-bluetooth/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Bluetooth")

--- a/grant-calendar/build.gradle.kts
+++ b/grant-calendar/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Calendar")

--- a/grant-compose/build.gradle.kts
+++ b/grant-compose/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -105,7 +105,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Compose")

--- a/grant-contacts/build.gradle.kts
+++ b/grant-contacts/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Contacts")

--- a/grant-core-koin/build.gradle.kts
+++ b/grant-core-koin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -79,7 +79,7 @@ repositories {
 publications.configureEach {
     (this as? MavenPublication)?.let {
         groupId = "dev.brewkits"
-        version = "2.2.3"
+        version = "2.2.4"
 
         pom {
             name.set("KMP Grant Koin")

--- a/grant-core/build.gradle.kts
+++ b/grant-core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -129,7 +129,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant")

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -182,8 +182,13 @@ actual class PlatformGrantDelegate(
                     val androidGrants = appGrant.toAndroidGrants()
                     if (androidGrants.isEmpty()) GrantStatus.GRANTED
                     else {
-                        val allGranted = androidGrants.all { 
-                            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED 
+                        // Full access is judged on the REQUIRED permissions only — see
+                        // toRequiredAndroidGrants(). Counting READ_MEDIA_VISUAL_USER_SELECTED here
+                        // misclassified a fully-granted gallery (IMAGES + VIDEO granted, USER_SELECTED
+                        // not) as denied → DENIED_ALWAYS (Issue: Lam gallery P0, 2026-07-09).
+                        val requiredGrants = appGrant.toRequiredAndroidGrants()
+                        val allGranted = requiredGrants.isNotEmpty() && requiredGrants.all {
+                            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
                         }
                         if (allGranted) GrantStatus.GRANTED
                         else if ((appGrant == AppGrant.GALLERY || appGrant == AppGrant.GALLERY_IMAGES_ONLY || appGrant == AppGrant.GALLERY_VIDEO_ONLY) && isPartialGalleryAccessGranted()) {
@@ -443,6 +448,22 @@ actual class PlatformGrantDelegate(
             else -> null
         }
     }
+
+    /**
+     * The permissions that must be granted for a [GrantStatus.GRANTED] (full-access) verdict.
+     *
+     * Differs from [toAndroidGrants] only for the gallery grants on API 34+:
+     * `READ_MEDIA_VISUAL_USER_SELECTED` belongs in the REQUEST array (it is what makes the
+     * Android 14 "Select photos" option appear in the system dialog) but must NOT gate full
+     * access. The OS can grant `READ_MEDIA_IMAGES` + `READ_MEDIA_VIDEO` while leaving
+     * `USER_SELECTED` denied (ADB `pm grant`, MDM policy, permission auto-reset edge states) —
+     * that IS full access. Counting it made [checkStatus] report a fully-granted gallery as
+     * denied, and the store-requested fallback escalated that to DENIED_ALWAYS
+     * (found via the Lam gallery P0, 2026-07-09). `USER_SELECTED` granted alone is
+     * partial access, handled by [isPartialGalleryAccessGranted].
+     */
+    internal fun AppGrant.toRequiredAndroidGrants(): List<String> =
+        toAndroidGrants().filterNot { it == READ_MEDIA_VISUAL_USER_SELECTED }
 
     internal fun AppGrant.toAndroidGrants(): List<String> {
         return when (this) {

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegateGalleryFullAccessTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegateGalleryFullAccessTest.kt
@@ -1,0 +1,93 @@
+package dev.brewkits.grant.impl
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantStatus
+import dev.brewkits.grant.InMemoryGrantStore
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for the 2.2.4 gallery full-access misclassification (found via the Lam
+ * gallery P0, 2026-07-09).
+ *
+ * On API 34+, `GALLERY.toAndroidGrants()` includes `READ_MEDIA_VISUAL_USER_SELECTED` so the
+ * system dialog offers "Select photos" — but full access must be judged on the REQUIRED
+ * permissions only (IMAGES/VIDEO). The OS can grant IMAGES + VIDEO while leaving
+ * USER_SELECTED denied (ADB `pm grant`, MDM policy, permission auto-reset edge states);
+ * counting USER_SELECTED made `checkStatus` report that fully-granted state as denied, and
+ * the store-requested fallback escalated it to DENIED_ALWAYS.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class PlatformGrantDelegateGalleryFullAccessTest {
+
+    private companion object {
+        const val USER_SELECTED = "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
+    }
+
+    private lateinit var context: Context
+    private lateinit var store: InMemoryGrantStore
+    private lateinit var delegate: PlatformGrantDelegate
+
+    @BeforeTest
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        store = InMemoryGrantStore()
+        delegate = PlatformGrantDelegate(context, store)
+    }
+
+    private fun grant(vararg permissions: String) {
+        Shadows.shadowOf(context as android.app.Application).grantPermissions(*permissions)
+    }
+
+    @Test
+    fun `IMAGES and VIDEO granted without USER_SELECTED is FULL access`() = runTest {
+        grant(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO)
+        // The escalation precondition of the original bug: the grant had been requested
+        // before, so the misclassified "not all granted" fell through to DENIED_ALWAYS.
+        store.setRequested(AppGrant.GALLERY)
+
+        assertEquals(GrantStatus.GRANTED, delegate.checkStatus(AppGrant.GALLERY))
+    }
+
+    @Test
+    fun `all three media permissions granted is FULL access`() = runTest {
+        grant(
+            Manifest.permission.READ_MEDIA_IMAGES,
+            Manifest.permission.READ_MEDIA_VIDEO,
+            USER_SELECTED,
+        )
+
+        assertEquals(GrantStatus.GRANTED, delegate.checkStatus(AppGrant.GALLERY))
+    }
+
+    @Test
+    fun `USER_SELECTED alone is PARTIAL access`() = runTest {
+        grant(USER_SELECTED)
+
+        assertEquals(GrantStatus.PARTIAL_GRANTED, delegate.checkStatus(AppGrant.GALLERY))
+    }
+
+    @Test
+    fun `nothing granted stays NOT_DETERMINED before any request`() = runTest {
+        assertEquals(GrantStatus.NOT_DETERMINED, delegate.checkStatus(AppGrant.GALLERY))
+    }
+
+    @Test
+    fun `GALLERY_IMAGES_ONLY with IMAGES granted is FULL access`() = runTest {
+        grant(Manifest.permission.READ_MEDIA_IMAGES)
+        store.setRequested(AppGrant.GALLERY_IMAGES_ONLY)
+
+        assertEquals(GrantStatus.GRANTED, delegate.checkStatus(AppGrant.GALLERY_IMAGES_ONLY))
+    }
+}

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
@@ -311,6 +311,12 @@ class GrantHandler(
      * A suspending alternative to [request].
      * Suspends the current coroutine until the grant flow completes (granted, denied, or dismissed).
      *
+     * When the flow needs a rationale or settings-guide dialog, it parks until the dialog host
+     * resumes it — so a host SHOULD be collecting [state] (e.g. `GrantDialog`) before
+     * requesting. With no host attached the flow does not park: the dialog state is cleared and
+     * the call completes immediately with the denied status (2.2.4 — previously it suspended
+     * forever, silently wedging the caller). The callback-based [request] is unaffected.
+     *
      * @param rationaleMessage Custom message for rationale dialog (optional)
      * @param settingsMessage  Custom message for settings dialog (optional)
      * @return The final [GrantStatus] after the flow completes. Returns [GrantStatus.BUSY]
@@ -334,6 +340,19 @@ class GrantHandler(
                 _status.value = currentStatus
                 eventListener?.onRequested(grant, currentStatus)
                 handleStatus(currentStatus, UiStrategy.StateBased(rationaleMessage, settingsMessage))
+                // 2.2.4 no-host safeguard: handleStatus may have parked the flow on a rationale /
+                // settings-guide dialog, to be resumed by the dialog host. If NO host is
+                // collecting [state], nothing can ever resume it and this suspend would hang
+                // FOREVER (real-world case: a headless requestSuspend on a grant whose dialogs
+                // the app never renders — the Lam gallery skeleton-hang, 2026-07-09). Detect
+                // "parked with no host", clear the unrenderable dialog state (mirroring
+                // onDismiss, including the rationale memory — the user never saw a dialog),
+                // and complete with the current status.
+                if (cont.isActive && _state.value.isVisible && !hasStateHost) {
+                    resetState()
+                    hasShownRationaleDialog = false
+                    clearCallbacks()
+                }
             } catch (e: CancellationException) {
                 clearCallbacks()
                 throw e
@@ -738,6 +757,24 @@ class GrantHandler(
     private fun resetState() {
         updateState { GrantUiState() }
     }
+
+    /**
+     * True when at least one collector is attached to [state] — i.e. a live dialog host
+     * (`GrantDialog` or a custom renderer) is observing this handler and can actually show the
+     * rationale / settings-guide UI and resume a parked flow via [onRationaleConfirmed] /
+     * [onSettingsConfirmed] / [onDismiss].
+     *
+     * Used only by [requestSuspend]'s no-host safeguard. The callback-based [request] flow
+     * deliberately raises dialog state without requiring a live collector (callers may read
+     * [state] however they like — the library's own tests read `state.value`), so this is NOT
+     * consulted inside the state machine itself.
+     *
+     * Contract for suspending callers: the dialog host must be attached BEFORE the request
+     * starts. `GrantDialog`'s `collectAsState` satisfies this naturally — it is in composition
+     * before any button that triggers a request can be tapped.
+     */
+    private val hasStateHost: Boolean
+        get() = _state.subscriptionCount.value > 0
 
     /**
      * Updates the state and persists it to savedStateDelegate.

--- a/grant-core/src/commonTest/kotlin/dev/brewkits/grant/regression/RequestSuspendNoHostTest.kt
+++ b/grant-core/src/commonTest/kotlin/dev/brewkits/grant/regression/RequestSuspendNoHostTest.kt
@@ -1,0 +1,135 @@
+package dev.brewkits.grant.regression
+
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.GrantHandler
+import dev.brewkits.grant.GrantStatus
+import dev.brewkits.grant.PlatformConfig
+import dev.brewkits.grant.fakes.FakeGrantManager
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression for the 2.2.4 `requestSuspend` no-host hang (found via the Lam gallery P0,
+ * 2026-07-09).
+ *
+ * Buggy behaviour
+ * ---------------
+ * `requestSuspend()` on a DENIED / DENIED_ALWAYS grant routed into the
+ * [dev.brewkits.grant.UiStrategy.StateBased] rationale / settings-guide branches, which raise
+ * dialog state and park the flow until the dialog host resumes it. When the app renders no
+ * dialog for that handler (a headless `requestSuspend`, e.g. a background pre-check before a
+ * screen loads), nothing could ever resume the flow — the caller suspended FOREVER. In Lam
+ * this wedged the gallery's entire first load on a skeleton grid.
+ *
+ * Fix
+ * ---
+ * After `handleStatus` returns, `requestSuspend` detects "parked on a dialog with no collector
+ * attached to [GrantHandler.state]" and completes with the current status instead, clearing
+ * the unrenderable dialog state (mirroring `onDismiss`, including the rationale memory). The
+ * callback-based `request()` flow is deliberately unchanged — raising dialog state without a
+ * live collector is a supported pattern there.
+ */
+class RequestSuspendNoHostTest {
+
+    private lateinit var testScope: TestScope
+
+    @BeforeTest
+    fun setup() {
+        testScope = TestScope(StandardTestDispatcher())
+    }
+
+    @Test
+    fun `requestSuspend with no host completes instead of hanging on DENIED_ALWAYS`() = testScope.runTest {
+        val manager = FakeGrantManager().apply {
+            mockStatus = GrantStatus.DENIED_ALWAYS
+            mockRequestResult = GrantStatus.DENIED_ALWAYS
+        }
+        val handler = GrantHandler(manager, AppGrant.GALLERY, this)
+
+        // No collector on handler.state — the pre-fix behaviour was an infinite suspend here,
+        // which runTest would surface as an uncompleted-coroutine failure.
+        val result = async { handler.requestSuspend() }
+        advanceUntilIdle()
+
+        assertTrue(result.isCompleted, "requestSuspend must not park when no dialog host exists")
+        assertEquals(GrantStatus.DENIED_ALWAYS, result.await())
+        assertFalse(handler.state.value.isVisible, "unrenderable dialog state must be cleared")
+    }
+
+    @Test
+    fun `requestSuspend with no host completes on a soft DENIED and keeps rationale fresh`() = testScope.runTest {
+        if (!PlatformConfig.isRationaleSupported) return@runTest
+
+        val manager = FakeGrantManager().apply {
+            mockStatus = GrantStatus.DENIED
+            mockRequestResult = GrantStatus.DENIED
+        }
+        val handler = GrantHandler(manager, AppGrant.GALLERY, this)
+
+        val result = async { handler.requestSuspend() }
+        advanceUntilIdle()
+
+        assertTrue(result.isCompleted, "requestSuspend must not park when no dialog host exists")
+        assertEquals(GrantStatus.DENIED, result.await())
+        assertFalse(handler.state.value.isVisible)
+
+        // The user never actually saw a rationale, so the memory must stay unset: a later
+        // hosted request{} still explains itself with the rationale dialog first.
+        handler.request { }
+        advanceUntilIdle()
+        assertTrue(
+            handler.state.value.showRationale,
+            "a later request must still surface the rationale — the no-host safeguard must not consume it"
+        )
+    }
+
+    @Test
+    fun `requestSuspend WITH a host still parks on the dialog and resumes via onDismiss`() = testScope.runTest {
+        val manager = FakeGrantManager().apply {
+            mockStatus = GrantStatus.DENIED_ALWAYS
+            mockRequestResult = GrantStatus.DENIED_ALWAYS
+        }
+        val handler = GrantHandler(manager, AppGrant.GALLERY, this)
+
+        // A live dialog host — what GrantDialog's collectAsState does in composition.
+        val host = launch { handler.state.collect { } }
+        advanceUntilIdle()
+
+        val result = async { handler.requestSuspend() }
+        advanceUntilIdle()
+
+        assertFalse(result.isCompleted, "with a host attached the flow must park on the settings guide")
+        assertTrue(handler.state.value.isVisible, "the settings guide must be visible for the host")
+        assertTrue(handler.state.value.showSettingsGuide)
+
+        handler.onDismiss()
+        advanceUntilIdle()
+        assertTrue(result.isCompleted, "onDismiss must resume the parked flow")
+
+        host.cancelAndJoin()
+    }
+
+    @Test
+    fun `requestSuspend with no host still returns GRANTED normally`() = testScope.runTest {
+        val manager = FakeGrantManager().apply {
+            mockStatus = GrantStatus.GRANTED
+        }
+        val handler = GrantHandler(manager, AppGrant.GALLERY, this)
+
+        val result = async { handler.requestSuspend() }
+        advanceUntilIdle()
+
+        assertTrue(result.isCompleted)
+        assertEquals(GrantStatus.GRANTED, result.await())
+    }
+}

--- a/grant-location-always/build.gradle.kts
+++ b/grant-location-always/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Location Always")

--- a/grant-motion/build.gradle.kts
+++ b/grant-motion/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.brewkits"
-version = "2.2.3"
+version = "2.2.4"
 
 kotlin {
     androidTarget {
@@ -75,7 +75,7 @@ publishing {
     publications.configureEach {
         (this as? MavenPublication)?.let {
             groupId = "dev.brewkits"
-            version = "2.2.3"
+            version = "2.2.4"
 
             pom {
                 name.set("KMP Grant Motion")


### PR DESCRIPTION
## Two bugs found via a consuming app's P0

A production app's gallery wedged **forever on its loading skeleton** (2026-07-09). Root-caused to two grant-core defects, both device-diagnosed on a Pixel 6 Pro running the consuming app.

### 1. `requestSuspend()` suspended forever when no dialog host is attached

On a `DENIED` / `DENIED_ALWAYS` grant, the `StateBased` flow raises rationale / settings-guide dialog state and parks until the dialog host (`GrantDialog` or a custom renderer of `GrantHandler.state`) resumes it via `onRationaleConfirmed()` / `onSettingsConfirmed()` / `onDismiss()`.

When the app renders **no dialog** for that handler — e.g. a headless `requestSuspend()` pre-check before a screen loads — nothing can ever resume the flow. The caller suspends forever, with no exception, no log, no timeout.

**Fix:** after `handleStatus` returns, `requestSuspend` detects *parked on a dialog with zero collectors on `state`* (`subscriptionCount == 0`), clears the unrenderable dialog state (mirroring `onDismiss`, including the rationale memory — the user never saw a dialog), and completes with the current status.

**Deliberately scoped to `requestSuspend` only.** The callback-based `request()` flow is untouched: raising dialog state without a live collector is a supported pattern there (the library's own tests — e.g. `Issue41DoubleDenialSettingsTest` — read `state.value` without collecting). An earlier draft gated inside `handleStatus` and was rejected for exactly that reason.

### 2. Android 14+: fully-granted gallery misreported as `DENIED_ALWAYS`

`GALLERY.toAndroidGrants()` includes `READ_MEDIA_VISUAL_USER_SELECTED` on API 34+ — required in the **request** array so the system dialog offers "Select photos" — but `checkStatus()` also counted it when judging full access (`all { granted }`).

The OS can grant `READ_MEDIA_IMAGES` + `READ_MEDIA_VIDEO` while leaving `USER_SELECTED` denied (ADB `pm grant`, MDM policy, permission auto-reset edge states). That fully-usable state failed the all-granted check, and because the grant was already in the request history, it escalated to `DENIED_ALWAYS` — which then fed bug #1.

**Fix:** full access is now judged on the required permissions only (new `toRequiredAndroidGrants()`, = `toAndroidGrants()` minus `USER_SELECTED`). The request array is unchanged, and `USER_SELECTED` granted alone still reports `PARTIAL_GRANTED`.

## Evidence

- **1348 tests, 0 failures** across `testDebugUnitTest` + `testReleaseUnitTest` + `iosSimulatorArm64Test`; Kover 82% floor passes.
- **9 new regression tests**, both fixes **mutation-verified** (reverting fix #2 fails 2 of `PlatformGrantDelegateGalleryFullAccessTest`; disabling the safeguard fails 2 of `RequestSuspendNoHostTest`).
- `RequestSuspendNoHostTest` includes a **with-host** test pinning that the park/resume dialog behaviour is fully preserved when a host exists.
- End-to-end validated in the consuming app: with these semantics its gallery loads, shows a recovery banner, and auto-reloads after the user grants access from Settings.

## Release

Version bumped to **2.2.4** in all 8 modules + `create-grant-maven-bundle-auto.sh` + CHANGELOG. Pure bugfix on the current toolchain (Kotlin 2.1.0 / Compose 1.9.3) — the open dependabot toolchain bumps (#42/#43/#44) are intentionally NOT included; see PR discussion.