### PR TITLE
docs: surface GrantGroupHandler and GrantEventListener in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ fun CameraScreen(viewModel: CameraViewModel) {
 - **Android process-death recovery** — a request in flight survives system-initiated process death via `SavedStateHandle`, with no timeouts.
 - **Deadlock-free by construction** — reentrant locking plus a `withTimeout` test policy that converts silent deadlocks into failing tests.
 - **19 built-in permissions** — Camera, Gallery (incl. Android 14 partial access), Location (incl. "Approximate"-only), Bluetooth, Local Network (Android 17), and more — plus `RawPermission` for anything the library doesn't ship yet.
+- **Permission groups as one unit** — `GrantGroupHandler` requests several permissions in a single batch, drives one `StateFlow` for the whole group, and fires `onAllGranted` only when every one is satisfied.
+- **Funnel analytics** — attach an optional `GrantEventListener` to any handler and observe every stage: requested, granted, denied, rationale shown, settings guide shown, settings opened.
 - **Service-state checks** — one call answers both "is the permission granted?" and "is GPS/Bluetooth actually on?".
 - **Material 3 dialogs** — optional `grant-compose` module renders the rationale and settings-guide flow out of the box.
 - **Heavily tested** — 2,100+ test executions across Android and iOS targets on every build, including concurrency-stress, regression, and process-death suites.
@@ -112,11 +114,6 @@ class CameraViewModel(grantManager: GrantManager) : ViewModel() {
         grantManager = grantManager,
         grant = AppGrant.CAMERA,
         scope = viewModelScope,
-        eventListener = object : GrantEventListener {
-            override fun onGranted(grant: GrantPermission, status: GrantStatus) {
-                analytics.track("camera_permission_granted")
-            }
-        }
     )
 
     // Suspend until the flow resolves…
@@ -129,6 +126,65 @@ class CameraViewModel(grantManager: GrantManager) : ViewModel() {
         .filter { it == GrantStatus.GRANTED }
         .onEach { cameraEngine.start() }
 }
+```
+
+### Request several permissions as one unit
+
+A feature that needs more than one permission — a video call needs Camera **and** Microphone — should not
+ask twice and should not half-succeed. `GrantGroupHandler` batches the system prompts into one pass, then
+walks any refusals individually to show the right rationale or settings guide. `onAllGranted` runs only when
+every permission in the group is satisfied:
+
+```kotlin
+class CallViewModel(grantManager: GrantManager) : ViewModel() {
+    val callGrants = GrantGroupHandler(
+        grantManager = grantManager,
+        grants = listOf(AppGrant.CAMERA, AppGrant.MICROPHONE),
+        scope = viewModelScope,
+    )
+
+    fun onJoinCall() {
+        callGrants.request(
+            rationaleMessages = mapOf(
+                AppGrant.CAMERA     to "Your camera is needed so others can see you.",
+                AppGrant.MICROPHONE to "Your microphone is needed so others can hear you.",
+            )
+        ) {
+            // Runs only when BOTH are granted.
+            callEngine.join()
+        }
+    }
+}
+```
+
+`callGrants.state` is a single `StateFlow<GrantGroupUiState>` for the whole group, and `GrantGroupDialog(callGrants)`
+renders it. Per-permission results stay available through `callGrants.statuses`.
+
+### Track the permission funnel
+
+Every handler takes an optional `GrantEventListener`. Each method has a default empty implementation, so
+override only the stages you measure — useful for finding where users actually drop off:
+
+```kotlin
+val cameraGrant = GrantHandler(
+    grantManager = grantManager,
+    grant = AppGrant.CAMERA,
+    scope = viewModelScope,
+    eventListener = object : GrantEventListener {
+        override fun onRationaleShown(grant: GrantPermission) {
+            analytics.track("permission_rationale_shown", grant.toString())
+        }
+
+        override fun onDenied(grant: GrantPermission, status: GrantStatus) {
+            // status distinguishes DENIED from DENIED_ALWAYS
+            analytics.track("permission_denied", grant.toString(), status.toString())
+        }
+
+        override fun onSettingsOpened(grant: GrantPermission) {
+            analytics.track("permission_settings_opened", grant.toString())
+        }
+    },
+)
 ```
 
 ### Chain sequential permissions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Grant Library — Roadmap
 
-> Last updated: 2026-09-03 · Current stable: **v2.3.0** (live on Maven Central) · Next: **v2.4.0**
+> Last updated: 2026-09-03 · Current stable: **v2.3.0** (live on Maven Central) · Next: **v2.4.0**, then **v2.5.0**
 
 ---
 
@@ -28,6 +28,16 @@
 - [x] Dokka 2.0.0 wired at the root as an aggregated publication over all eight modules (`demo` excluded); `./gradlew dokkaGenerate` → `build/dokka/html`.
 - [x] Opted into the Dokka V2 Gradle plugin in `gradle.properties` — 2.0.0 still defaults to V1, which is deprecated and removed in 2.1.0.
 - [x] Added `.github/workflows/docs.yml`: builds on a macOS runner and deploys to GitHub Pages on every `v*` tag. **Needs Pages enabled** in repo settings (Settings → Pages → Source: GitHub Actions) before the first run.
+
+### v2.5.0 — Group UX
+
+**1. Opt-in pre-request rationale for groups**
+- [ ] A single "priming" dialog that explains a whole `GrantGroupHandler` set **before** any system prompt fires, instead of the current per-permission rationale shown **after** a refusal.
+- [ ] **Additive and opt-in — the default flow does not change.** Today `GrantGroupHandler` batches the system prompts first and then walks refusals individually (`rationaleMessages: Map<GrantPermission, String>`). That order deliberately follows the platform: Android's `shouldShowRequestPermissionRationale()` only returns `true` *after* a denial, so OS-native rationale is inherently post-denial. Priming is an app-level pattern layered on top, not a replacement.
+- [ ] **Where it pays:** sensitive permissions where a cold prompt is expensive because the OS grants a limited number of asks — `LOCATION_ALWAYS`, `CONTACTS`, `CALENDAR`. **Where it costs:** users who would have accepted anyway now pay an extra tap, so it must never become the default.
+- [ ] Needs a `GrantGroupUiState` flag for the priming stage and a `GrantEventListener` event so the funnel can measure whether priming actually reduces denials — otherwise the feature cannot be evaluated.
+
+*Origin: an external evaluation proposed this alongside "permission funnel analytics" and "atomic batch requests". Those two already ship — `GrantEventListener` (v2.1.0) and `GrantGroupHandler` respectively — and the merged pre-request rationale was the one genuinely new idea in the proposal. That an expert reviewer missed both shipped features was itself the finding: `GrantGroupHandler` appeared **zero** times in the README and `GrantEventListener` only once, buried inside a code sample. Both now have their own Features bullet and Usage section.*
 
 ## 📋 Backlog / Considering
 


### PR DESCRIPTION
An external evaluation of Grant proposed two items as **future** work:

1. *Permission Funnel Analytics Hook* — `onPromptShown`, `onUserAction(Granted/Denied/Settings)`, `onSettingsOpened`
2. *Atomic Batch Permission Requests* — group several permissions into one logical transaction (its example: a video call needing `CAMERA` + `MICROPHONE`)

**Both already ship.**

| Proposed | Exists as | Since |
|---|---|---|
| `onPromptShown` | `onRationaleShown` + `onSettingsGuideShown` | v2.1.0 |
| `onUserAction(Granted/Denied)` | `onGranted` / `onDenied` | v2.1.0 |
| `onUserAction(Settings)` | `onSettingsOpened` | v2.1.0 |
| Atomic batch / transaction | `GrantGroupHandler` + `onAllGranted` | — |

The shipped analytics surface is in fact *finer* than what was proposed: it separates rationale from settings-guide impressions, and `onDenied` distinguishes `DENIED` from `DENIED_ALWAYS`.

### The actual finding

A reviewer thorough enough to assess the library as *industrial-grade* missed two headline features. That is a **documentation problem, not a feature gap** — and it is measurable:

```
GrantGroupHandler   → README: 0 occurrences
GrantEventListener  → README: 1 occurrence, buried in the camera code sample
```

`GrantGroupHandler` is the direct answer to the very use case the evaluation raised, and the front door never mentioned it. This is the same root cause as the missing v2.1.0 migration chapter fixed in #66: features ship, and the docs do not say so.

## README changes

- **Two new Features bullets** — permission groups as one unit; funnel analytics.
- **New Usage section: "Request several permissions as one unit"** — uses the video-call case (Camera + Microphone) from the evaluation. Documents the real behaviour: system prompts batched into one pass, refusals then walked individually for per-permission rationale/settings guidance, and `onAllGranted` firing only when every permission is satisfied. Mentions `state`, `statuses` and `GrantGroupDialog`.
- **New Usage section: "Track the permission funnel"** — overrides `onRationaleShown`, `onDenied`, `onSettingsOpened`, and notes that `status` distinguishes `DENIED` from `DENIED_ALWAYS`.
- The camera example no longer carries an inline `eventListener`; the dedicated section owns that topic.

Snippets use **block bodies** rather than expression bodies, so they compile regardless of what the reader's `analytics.track()` returns. Every symbol in the new snippets was checked against the source, including `AppGrant.MICROPHONE` and the exact `request(rationaleMessages, settingsMessages, onAllGranted)` signature.

## ROADMAP — new v2.5.0 "Group UX"

The one genuinely new idea in the proposal was a **merged rationale shown _before_ the system prompt**. Grant currently does the opposite: batch request first, then per-permission rationale on refusal.

That order is deliberate, not an oversight — Android's `shouldShowRequestPermissionRationale()` only returns `true` **after** a denial, so OS-native rationale is inherently post-denial. A pre-request "priming" screen is an app-level pattern layered on top.

Recorded as **additive and opt-in, explicitly not the new default**, with:

- **Where it pays** — `LOCATION_ALWAYS`, `CONTACTS`, `CALENDAR`, where a cold prompt is expensive because the OS grants a limited number of asks.
- **Where it costs** — an extra tap for every user who would have accepted anyway.
- **A measurement requirement** — a `GrantGroupUiState` stage flag and a `GrantEventListener` event, so the funnel can actually show whether priming reduces denials. Without that the feature cannot be evaluated after shipping.

---

Docs-only; no `src/` file is touched. Per the new trigger policy from #66, CI runs on merge to `main` rather than on this PR.