### PR TITLE
feat: explicitApi + R8 validation + SBOM + support policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Build demo app
         run: ./gradlew :demo:assembleDebug
 
+      # Release is minified (see demo/build.gradle.kts), so this is the R8 regression
+      # guard: grant-core ships no consumer ProGuard rules, on the basis that its
+      # manifest-declared components are kept automatically. If that ever stops being
+      # true, this step fails here rather than in a consumer's release build.
+      - name: Build demo app under R8 (release)
+        run: ./gradlew :demo:assembleRelease
+
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ Most KMP permission libraries are thin wrappers around the native APIs. Grant is
 | Android 14 partial access | ✅ | partial | ✅ |
 | Custom permissions | ✅ | limited | limited |
 
+## Size and supply chain
+
+| Artifact | Release AAR |
+|---|---|
+| `grant-core` | 292 KB |
+| `grant-compose` | 32 KB |
+| `grant-core-koin` | 8 KB |
+| `grant-contacts` · `grant-calendar` · `grant-motion` · `grant-bluetooth` · `grant-location-always` | 4 KB each |
+
+Download size is not app size. In a real R8-minified build (the demo, with
+`-allowaccessmodification`), Grant contributes **83 classes** out of 2,686 — the rest is
+stripped. Adding an optional module such as `grant-bluetooth` costs single-digit kilobytes.
+
+Every published module emits a **CycloneDX SBOM** (`./gradlew cyclonedxBom` →
+`<module>/build/reports/bom.json`), so you can answer "what is inside this dependency?"
+without unpacking it.
+
+**No Baseline Profile is shipped, deliberately.** Grant's entire startup contribution is one
+`ContentProvider.onCreate()` that registers an activity-lifecycle callback; there is no hot
+path for AOT compilation to improve. The permission request path is user-triggered and gated
+behind a system dialog, where JIT versus AOT is not measurable. A profile here would be
+ceremony, not speed.
+
 ## Supported permissions
 
 20 built-in permissions across Camera, Microphone, Gallery (read and save-only), Storage, Location, Notifications, Bluetooth, Contacts, Calendar, Motion, Exact Alarms, Nearby Wi-Fi, and Local Network — anything else via `RawPermission`.
@@ -227,6 +250,7 @@ Most KMP permission libraries are thin wrappers around the native APIs. Grant is
 | [iOS setup](docs/platform-specific/ios/info-plist.md) | `Info.plist` configuration — read before shipping |
 | [Migration guide](docs/MIGRATION_GUIDE.md) | Upgrading to 2.3.0 (and from v1.x → 2.x) |
 | [Service checking](docs/grant-core/SERVICES.md) | Combining permission and hardware service checks |
+| [Support policy](SUPPORT.md) | Versioning, supported versions, platform support, and what Grant will not do |
 | [Manual injection](docs/MANUAL_INJECTION.md) | Using Grant without a DI framework |
 | [Android reliability](docs/FIX_DEAD_CLICK_ANDROID.md) | How Grant fixes "dead clicks" on Android |
 | [Best practices](docs/BEST_PRACTICES.md) | Patterns for production apps |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,21 @@
 - [x] The widely reported "unified Privacy Management declaration" in OS 27 is an **MDM/enterprise feature** configured by IT administrators for managed apps, not a developer API. It does not change Grant's design, and `GrantGroupHandler` is not superseded by it.
 - [x] Consumer coverage of "granular photo editing access" in iOS 27 could **not** be corroborated at the PhotoKit/`PHAccessLevel` level. Left unverified rather than planned around; revisit when Apple's own documentation lands.
 
+### v2.4.1 — API and runtime guarantees ✅
+
+**4. Validated under R8** ✅
+- [x] `demo` release now builds with `isMinifyEnabled = true` and `-allowaccessmodification`; `ci.yml` runs `:demo:assembleRelease` so it stays validated. R8 had **never** been run against Grant before this.
+- [x] Confirmed **no consumer ProGuard rules are needed**, with evidence rather than assumption: `GrantRequestActivity` and `GrantInitializer` keep their names (manifest-declared, so R8 keeps them), while `AppGrant`/`GrantHandler`/`GrantStatus` are renamed but present.
+- [x] The finding that mattered: **enum constant name strings survive in the DEX**. `SharedPreferencesGrantStore` persists request history keyed on `AppGrant.name`, so R8 rewriting those strings would have silently broken history across builds. Checked in the release DEX, not inferred from the mapping file.
+- [x] `demo/proguard-rules.pro` is deliberately free of Grant-specific keeps — a speculative keep file would disable optimisation for every consumer and hide exactly the breakage this build exists to detect.
+
+**5. `explicitApi()` on all eight modules** ✅
+- [x] Roughly 340 declarations gained explicit visibility, plus nine explicit return types (`GrantEventListener`'s no-op defaults, a `when`-expression extension, an `openSettings()` override, a mutable property, and the Koin `Module` values).
+- [x] **The ABI dumps did not change by a single line.** That is the proof the churn was mechanical and no public surface moved — the reason the ABI gate was worth landing first.
+
+**6. Privacy position pinned** ✅
+- [x] `GrantLogger` defaults to `isEnabled = false` with no handler installed, so a library sitting in front of contacts, calendar and location writes nothing the host app did not ask for. Now covered by `LoggerPrivacyDefaultTest`, including that a disabled logger emits nothing even when a handler is attached.
+
 ## 📋 Backlog / Considering
 
 *Not committed to a version yet — pulled into a milestone when a consumer actually asks.*

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,64 @@
+# Support policy
+
+What you can rely on when you put Grant in a production app.
+
+## Versioning
+
+Grant follows semantic versioning.
+
+| Change | Version bump |
+|---|---|
+| Breaking public API change | major |
+| New permission, new API, new module | minor |
+| Bug fix, docs, dependency bump | patch |
+
+The public API surface is not a matter of opinion: every published module commits an ABI
+dump under `<module>/api/`, and CI fails on any undeclared change to it. A release cannot be
+bundled with an unreviewed API change — `create-grant-maven-bundle-auto.sh` runs the same
+check. See `CLAUDE.md` for the workflow.
+
+## Supported versions
+
+The **latest minor of the current major** receives fixes. When a new major ships, the
+previous major receives security fixes for **six months**.
+
+Security issues: see [SECURITY.md](SECURITY.md). Please do not report them in public issues.
+
+## Platform support
+
+| | Supported |
+|---|---|
+| Android | `minSdk 26` (Android 8.0) — `compileSdk 36`, with Android 17 (API 37) behaviour handled |
+| iOS | arm64, simulator arm64, x64 — except `grant-compose`, which dropped iosX64 in 2.3.0 because Compose Multiplatform 1.11 stopped publishing that target |
+| Kotlin | 2.4.x |
+| JVM target | 17 |
+
+**`minSdk` is raised only in a major release**, and only when the lowest supported level is
+below roughly 1% of active devices. A `minSdk` bump breaks consuming apps that support older
+devices, so it is treated as a breaking change, not housekeeping.
+
+**New Android and iOS releases** are supported in a minor version once their permission
+behaviour is understood and tested — not on the day the beta drops. Grant's value is in the
+edge cases, and shipping an untested guess about a new OS would work against that.
+
+## What Grant will not do
+
+Stated so it can be relied on:
+
+- **No permissions are added to your app.** `grant-core` declares zero `<uses-permission>`
+  entries; nothing appears on your Play listing that you did not ask for. If you use
+  `ServiceType.WIFI`, you declare `ACCESS_WIFI_STATE` yourself — see the installation guide.
+- **No data collection, no network calls, no analytics.** Grant talks to the OS permission
+  APIs and nothing else.
+- **No logging unless you ask for it.** `GrantLogger.isEnabled` defaults to `false` with no
+  handler installed. Only permission identifiers and flow state are ever logged — never the
+  contents of a permission.
+- **No review-circumvention techniques.** An obfuscated `requestAlwaysAuthorization` call was
+  proposed and rejected in v2.2.0 as an App Store Guideline 2.3.1 risk; module isolation is
+  the transparent fix. See `docs/ios/APPLE_FRAMEWORK_LINKING_ISSUE.md`.
+
+## Reporting a problem
+
+Open an issue with the platform, OS version, Grant version, and the permission involved.
+Permission bugs are usually specific to an API level or an OS dialog variant, and those
+three facts are what make one reproducible.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx) apply false
 }
 
 subprojects {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -104,7 +104,19 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            // Minification is ON so that every release build of the demo exercises the
+            // library under R8 — the configuration nearly every production consumer uses,
+            // and one grant-core had never been validated against.
+            //
+            // grant-core intentionally ships no consumer ProGuard rules: its Activity and
+            // ContentProvider are declared in the library manifest, so R8 keeps them
+            // without help. This build is what turns that from an assumption into a
+            // checked fact. See demo/proguard-rules.pro.
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 

--- a/demo/proguard-rules.pro
+++ b/demo/proguard-rules.pro
@@ -1,0 +1,21 @@
+# R8 configuration for the Grant demo app.
+#
+# This file exists to VALIDATE the library, not to work around it. grant-core ships no
+# consumer rules, on the theory that it needs none: GrantRequestActivity and
+# GrantInitializer are declared in the library manifest, and R8 keeps manifest-referenced
+# components automatically.
+#
+# Building this app with minification proves or disproves that theory. If a rule ever has
+# to be added below to make the permission flow work, that rule belongs in a
+# consumer-rules.pro inside grant-core instead — because every consuming app would need it
+# too, and they cannot be expected to discover it themselves.
+#
+# Deliberately empty of Grant-specific keeps.
+
+# Full mode plus access modification: the most aggressive configuration a consuming app is
+# likely to use, so the library is tested against the worst realistic case rather than the
+# default.
+-allowaccessmodification
+
+# Keep the demo's own entry point readable in stack traces during manual verification.
+-keepattributes SourceFile,LineNumberTable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ turbine = "1.0.0"
 kotest = "5.9.1"
 kover = "0.9.8"
 dokka = "2.0.0"
+cyclonedx = "1.4.0"
 robolectric = "4.12.1"
 atomicfu = "0.33.0"
 androidx-test-core = "1.5.0"
@@ -57,3 +58,4 @@ composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "k
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }

--- a/grant-bluetooth/build.gradle.kts
+++ b/grant-bluetooth/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -112,4 +118,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-bluetooth/src/androidMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
+++ b/grant-bluetooth/src/androidMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.bluetooth
 /**
  * Entry point for initializing the Grant Bluetooth module.
  */
-actual object GrantBluetooth {
+public actual object GrantBluetooth {
     /**
      * No-op on Android, as Android handles permissions via Manifest and Intents.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         // No-op
     }
 }

--- a/grant-bluetooth/src/commonMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
+++ b/grant-bluetooth/src/commonMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.bluetooth
 /**
  * Entry point for initializing the Grant Bluetooth module.
  */
-expect object GrantBluetooth {
+public expect object GrantBluetooth {
     /**
      * Initializes the Bluetooth permission handler.
      * Must be called before requesting Bluetooth permissions.
      * It is safe to call this multiple times.
      */
-    fun initialize()
+    public fun initialize()
 }

--- a/grant-bluetooth/src/iosMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
+++ b/grant-bluetooth/src/iosMain/kotlin/dev/brewkits/grant/bluetooth/GrantBluetooth.kt
@@ -9,14 +9,14 @@ import dev.brewkits.grant.delegates.BluetoothManagerDelegate
 /**
  * Entry point for initializing the Grant Bluetooth module.
  */
-actual object GrantBluetooth {
+public actual object GrantBluetooth {
     private var isInitialized = false
     private val delegate by lazy { BluetoothManagerDelegate() }
 
     /**
      * Registers the Bluetooth permission handler for iOS.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         if (isInitialized) return
         isInitialized = true
         IosPermissionHandlerRegistry.register(AppGrant.BLUETOOTH.identifier, BluetoothPermissionHandler(delegate))

--- a/grant-calendar/build.gradle.kts
+++ b/grant-calendar/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -112,4 +118,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-calendar/src/androidMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
+++ b/grant-calendar/src/androidMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.calendar
 /**
  * Entry point for initializing the Grant Calendar module.
  */
-actual object GrantCalendar {
+public actual object GrantCalendar {
     /**
      * No-op on Android, as Android handles permissions via Manifest and Intents.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         // No-op
     }
 }

--- a/grant-calendar/src/commonMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
+++ b/grant-calendar/src/commonMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.calendar
 /**
  * Entry point for initializing the Grant Calendar module.
  */
-expect object GrantCalendar {
+public expect object GrantCalendar {
     /**
      * Initializes the Calendar permission handler.
      * Must be called before requesting Calendar permissions.
      * It is safe to call this multiple times.
      */
-    fun initialize()
+    public fun initialize()
 }

--- a/grant-calendar/src/iosMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
+++ b/grant-calendar/src/iosMain/kotlin/dev/brewkits/grant/calendar/GrantCalendar.kt
@@ -7,13 +7,13 @@ import dev.brewkits.grant.handlers.CalendarPermissionHandler
 /**
  * Entry point for initializing the Grant Calendar module.
  */
-actual object GrantCalendar {
+public actual object GrantCalendar {
     private var isInitialized = false
 
     /**
      * Registers the Calendar permission handler for iOS.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         if (isInitialized) return
         isInitialized = true
         IosPermissionHandlerRegistry.register(AppGrant.CALENDAR.identifier, CalendarPermissionHandler())

--- a/grant-compose/build.gradle.kts
+++ b/grant-compose/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -27,6 +28,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -150,4 +156,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantComposeExtensions.kt
+++ b/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantComposeExtensions.kt
@@ -35,7 +35,7 @@ import dev.brewkits.grant.GrantUiState
  * @return State holder containing the current GrantUiState
  */
 @Composable
-fun GrantHandler.collectAsStateWithLifecycle(): State<GrantUiState> {
+public fun GrantHandler.collectAsStateWithLifecycle(): State<GrantUiState> {
     return this.state.collectAsStateWithLifecycle()
 }
 
@@ -58,7 +58,7 @@ fun GrantHandler.collectAsStateWithLifecycle(): State<GrantUiState> {
  * @return State holder containing the current GrantStatus
  */
 @Composable
-fun GrantHandler.collectStatusAsState(): State<GrantStatus> {
+public fun GrantHandler.collectStatusAsState(): State<GrantStatus> {
     return this.status.collectAsStateWithLifecycle()
 }
 
@@ -77,7 +77,7 @@ fun GrantHandler.collectStatusAsState(): State<GrantStatus> {
  * @return State holder containing the current GrantGroupUiState
  */
 @Composable
-fun GrantGroupHandler.collectAsStateWithLifecycle(): State<GrantGroupUiState> {
+public fun GrantGroupHandler.collectAsStateWithLifecycle(): State<GrantGroupUiState> {
     return this.state.collectAsStateWithLifecycle()
 }
 
@@ -96,7 +96,7 @@ fun GrantGroupHandler.collectAsStateWithLifecycle(): State<GrantGroupUiState> {
  * @return State holder containing the current map of grant statuses
  */
 @Composable
-fun GrantGroupHandler.collectStatusesAsState(): State<Map<GrantPermission, GrantStatus>> {
+public fun GrantGroupHandler.collectStatusesAsState(): State<Map<GrantPermission, GrantStatus>> {
     return this.statuses.collectAsStateWithLifecycle()
 }
 
@@ -104,6 +104,6 @@ fun GrantGroupHandler.collectStatusesAsState(): State<Map<GrantPermission, Grant
  * Extension function to collect state from GrantAndServiceHandler in a Composable.
  */
 @Composable
-fun GrantAndServiceHandler.collectAsStateWithLifecycle(): State<GrantAndServiceUiState> {
+public fun GrantAndServiceHandler.collectAsStateWithLifecycle(): State<GrantAndServiceUiState> {
     return this.state.collectAsStateWithLifecycle()
 }

--- a/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantDialogStrings.kt
+++ b/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantDialogStrings.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * a `strings` parameter directly to [GrantDialog].
  */
 @Immutable
-data class GrantDialogStrings(
+public data class GrantDialogStrings(
     val rationaleTitle: String = "Permission Required",
     val rationaleConfirm: String = "Continue",
     val rationaleDismiss: String = "Cancel",
@@ -60,7 +60,7 @@ data class GrantDialogStrings(
  * Default value is the English [GrantDialogStrings] — used when no
  * [GrantDialogStringsProvider] ancestor is present.
  */
-val LocalGrantDialogStrings: ProvidableCompositionLocal<GrantDialogStrings> =
+public val LocalGrantDialogStrings: ProvidableCompositionLocal<GrantDialogStrings> =
     staticCompositionLocalOf { GrantDialogStrings() }
 
 /**
@@ -70,7 +70,7 @@ val LocalGrantDialogStrings: ProvidableCompositionLocal<GrantDialogStrings> =
  * Place this once inside your app theme or root composable.
  */
 @Composable
-fun GrantDialogStringsProvider(
+public fun GrantDialogStringsProvider(
     strings: GrantDialogStrings,
     content: @Composable () -> Unit,
 ) {

--- a/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantDialogs.kt
+++ b/grant-compose/src/commonMain/kotlin/dev/brewkits/grant/compose/GrantDialogs.kt
@@ -50,7 +50,7 @@ private enum class ServiceDialogKind { None, Rationale, PermissionSettings, Serv
  * when the dialog kind actually changes.
  */
 @Composable
-fun GrantDialog(
+public fun GrantDialog(
     handler: GrantHandler,
     strings: GrantDialogStrings = LocalGrantDialogStrings.current,
 ) {
@@ -104,7 +104,7 @@ fun GrantDialog(
  * dialog branch unless the visible dialog kind actually changes.
  */
 @Composable
-fun GrantGroupDialog(
+public fun GrantGroupDialog(
     handler: GrantGroupHandler,
     strings: GrantDialogStrings = LocalGrantDialogStrings.current,
 ) {
@@ -157,7 +157,7 @@ fun GrantGroupDialog(
  * updates such as service availability ticks.
  */
 @Composable
-fun GrantAndServiceDialog(
+public fun GrantAndServiceDialog(
     handler: GrantAndServiceHandler,
     strings: GrantDialogStrings = LocalGrantDialogStrings.current,
 ) {
@@ -215,7 +215,7 @@ fun GrantAndServiceDialog(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GrantRationaleDialog(
+public fun GrantRationaleDialog(
     message: String,
     title: String = "Permission Required",
     confirmText: String = "Continue",
@@ -271,7 +271,7 @@ fun GrantRationaleDialog(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GrantSettingsDialog(
+public fun GrantSettingsDialog(
     message: String,
     title: String = "Permission Denied",
     confirmText: String = "Open Settings",

--- a/grant-contacts/build.gradle.kts
+++ b/grant-contacts/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -112,4 +118,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-contacts/src/androidMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
+++ b/grant-contacts/src/androidMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.contacts
 /**
  * Entry point for initializing the Grant Contacts module.
  */
-actual object GrantContacts {
+public actual object GrantContacts {
     /**
      * No-op on Android, as Android handles permissions via Manifest and Intents.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         // No-op
     }
 }

--- a/grant-contacts/src/commonMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
+++ b/grant-contacts/src/commonMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.contacts
 /**
  * Entry point for initializing the Grant Contacts module.
  */
-expect object GrantContacts {
+public expect object GrantContacts {
     /**
      * Initializes the Contacts permission handler.
      * Must be called before requesting Contacts permissions.
      * It is safe to call this multiple times.
      */
-    fun initialize()
+    public fun initialize()
 }

--- a/grant-contacts/src/iosMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
+++ b/grant-contacts/src/iosMain/kotlin/dev/brewkits/grant/contacts/GrantContacts.kt
@@ -7,13 +7,13 @@ import dev.brewkits.grant.handlers.ContactsPermissionHandler
 /**
  * Entry point for initializing the Grant Contacts module.
  */
-actual object GrantContacts {
+public actual object GrantContacts {
     private var isInitialized = false
 
     /**
      * Registers the Contacts permission handler for iOS.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         if (isInitialized) return
         isInitialized = true
         IosPermissionHandlerRegistry.register(AppGrant.CONTACTS.identifier, ContactsPermissionHandler())

--- a/grant-core-koin/build.gradle.kts
+++ b/grant-core-koin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -24,6 +25,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -118,4 +124,14 @@ publications.configureEach {
 }
 }
 
-
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
+}

--- a/grant-core-koin/src/androidMain/kotlin/dev/brewkits/grant/di/GrantPlatformModule.android.kt
+++ b/grant-core-koin/src/androidMain/kotlin/dev/brewkits/grant/di/GrantPlatformModule.android.kt
@@ -3,6 +3,7 @@ package dev.brewkits.grant.di
 import android.content.Context
 import dev.brewkits.grant.SharedPreferencesGrantStore
 import dev.brewkits.grant.impl.PlatformGrantDelegate
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
 /**
@@ -14,7 +15,7 @@ import org.koin.dsl.module
  * **Requirements**:
  * - Android Context must be provided by the app's DI setup
  */
-actual val grantPlatformModule = module {
+public actual val grantPlatformModule: Module = module {
     single {
         val context = get<Context>()
         PlatformGrantDelegate(

--- a/grant-core-koin/src/commonMain/kotlin/dev/brewkits/grant/di/GrantModule.kt
+++ b/grant-core-koin/src/commonMain/kotlin/dev/brewkits/grant/di/GrantModule.kt
@@ -30,7 +30,7 @@ import org.koin.dsl.module
  * }
  * ```
  */
-val grantModule = module {
+public val grantModule: Module = module {
     // Grant Manager
     single<GrantManager> {
         DefaultGrantManager(
@@ -59,4 +59,4 @@ val grantModule = module {
  * - Android: Context, PlatformGrantDelegate
  * - iOS: PlatformGrantDelegate
  */
-expect val grantPlatformModule: Module
+public expect val grantPlatformModule: Module

--- a/grant-core-koin/src/iosMain/kotlin/dev/brewkits/grant/di/GrantPlatformModule.ios.kt
+++ b/grant-core-koin/src/iosMain/kotlin/dev/brewkits/grant/di/GrantPlatformModule.ios.kt
@@ -2,6 +2,7 @@ package dev.brewkits.grant.di
 
 import dev.brewkits.grant.InMemoryGrantStore
 import dev.brewkits.grant.impl.PlatformGrantDelegate
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
 /**
@@ -10,7 +11,7 @@ import org.koin.dsl.module
  * Provides PlatformGrantDelegate that handles all iOS grant requests
  * using native iOS frameworks (AVFoundation, CoreLocation, etc.).
  */
-actual val grantPlatformModule = module {
+public actual val grantPlatformModule: Module = module {
     single {
         PlatformGrantDelegate(store = InMemoryGrantStore())
     }

--- a/grant-core/build.gradle.kts
+++ b/grant-core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Two breaking changes shipped unnoticed in v2.1.0 (GrantDialogStrings, the
@@ -193,4 +199,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/AndroidSavedStateDelegate.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/AndroidSavedStateDelegate.kt
@@ -43,7 +43,7 @@ import androidx.lifecycle.SavedStateHandle
  *
  * @param savedStateHandle The SavedStateHandle from ViewModel
  */
-class AndroidSavedStateDelegate(
+public class AndroidSavedStateDelegate(
     private val savedStateHandle: SavedStateHandle
 ) : SavedStateDelegate {
 

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantFactory.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/GrantFactory.android.kt
@@ -9,7 +9,7 @@ import dev.brewkits.grant.impl.PlatformGrantDelegate
  * Requires an Android [Context]. When [store] is `null`, a persistent
  * [SharedPreferencesGrantStore] is used so request history survives process death.
  */
-actual fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate {
+public actual fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate {
     require(context is Context) {
         "Android requires Context. Pass applicationContext to GrantFactory.create().\n" +
         "Example: GrantFactory.create(applicationContext)"

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/ServiceFactory.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/ServiceFactory.android.kt
@@ -4,18 +4,18 @@ import android.content.Context
 import dev.brewkits.grant.impl.MyServiceManager
 import dev.brewkits.grant.impl.PlatformServiceDelegate
 
-actual object ServiceFactory {
+public actual object ServiceFactory {
     private lateinit var applicationContext: Context
 
     /**
      * Initialize with Android application context.
      * Call this in Application.onCreate()
      */
-    fun init(context: Context) {
+    public fun init(context: Context) {
         applicationContext = context.applicationContext
     }
 
-    actual fun createServiceManager(): ServiceManager {
+    public actual fun createServiceManager(): ServiceManager {
         if (!::applicationContext.isInitialized) {
             throw IllegalStateException(
                 "ServiceFactory not initialized. Call ServiceFactory.init(context) in Application.onCreate()"

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/SharedPreferencesGrantStore.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/SharedPreferencesGrantStore.kt
@@ -45,7 +45,7 @@ import dev.brewkits.grant.utils.withLock
  * `grantPlatformModule`). Apps that prefer the in-memory behavior can pass
  * [InMemoryGrantStore] explicitly.
  */
-class SharedPreferencesGrantStore(context: Context) : GrantStore {
+public class SharedPreferencesGrantStore(context: Context) : GrantStore {
 
     private val appContext = context.applicationContext
 

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/AndroidGrantLauncher.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/AndroidGrantLauncher.kt
@@ -16,7 +16,7 @@ import dev.brewkits.grant.GrantLauncher
  * permission dialog returns — the registered [ActivityResultLauncher] callback routes
  * the result back to it.
  */
-class AndroidGrantLauncher private constructor() : GrantLauncher {
+public class AndroidGrantLauncher private constructor() : GrantLauncher {
 
     @Volatile private var pendingCallback: ((Map<String, Boolean>) -> Unit)? = null
     private lateinit var launcher: ActivityResultLauncher<Array<String>>
@@ -26,13 +26,13 @@ class AndroidGrantLauncher private constructor() : GrantLauncher {
         launcher.launch(permissions.toTypedArray())
     }
 
-    companion object {
+    public companion object {
         /**
          * Creates an [AndroidGrantLauncher] from an Activity.
          *
          * Call this during `onCreate` or as a property initializer, before the Activity is STARTED.
          */
-        fun from(activity: ComponentActivity): AndroidGrantLauncher {
+        public fun from(activity: ComponentActivity): AndroidGrantLauncher {
             val grantLauncher = AndroidGrantLauncher()
             grantLauncher.launcher = activity.registerForActivityResult(
                 ActivityResultContracts.RequestMultiplePermissions()
@@ -48,7 +48,7 @@ class AndroidGrantLauncher private constructor() : GrantLauncher {
          *
          * Call this during `onCreate` or as a property initializer, before the Fragment is STARTED.
          */
-        fun from(fragment: Fragment): AndroidGrantLauncher {
+        public fun from(fragment: Fragment): AndroidGrantLauncher {
             val grantLauncher = AndroidGrantLauncher()
             grantLauncher.launcher = fragment.registerForActivityResult(
                 ActivityResultContracts.RequestMultiplePermissions()

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/GrantRequestActivity.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/GrantRequestActivity.kt
@@ -18,19 +18,19 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.UUID
 
-class GrantRequestViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
-    companion object {
+public class GrantRequestViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+    public companion object {
         private const val KEY_ALREADY_LAUNCHED = "already_launched"
         private const val KEY_REQUEST_ID = "request_id"
     }
 
-    var alreadyLaunched: Boolean
+    public var alreadyLaunched: Boolean
         get() = savedStateHandle.get<Boolean>(KEY_ALREADY_LAUNCHED) ?: false
         set(value) {
             savedStateHandle[KEY_ALREADY_LAUNCHED] = value
         }
 
-    var requestId: String?
+    public var requestId: String?
         get() = savedStateHandle.get<String>(KEY_REQUEST_ID)
         set(value) {
             savedStateHandle[KEY_REQUEST_ID] = value
@@ -40,7 +40,7 @@ class GrantRequestViewModel(private val savedStateHandle: SavedStateHandle) : Vi
 /**
  * Transparent Activity for handling runtime grant requests.
  */
-class GrantRequestActivity : ComponentActivity() {
+public class GrantRequestActivity : ComponentActivity() {
 
     private var requestMultipleGrantsLauncher: ActivityResultLauncher<Array<String>>? = null
     private var currentGrants = arrayOf<String>()
@@ -143,7 +143,7 @@ class GrantRequestActivity : ComponentActivity() {
         pendingResults[requestId]?.complete(result)
     }
 
-    companion object {
+    public companion object {
         private const val TAG = "GrantRequestActivity"
         private const val EXTRA_GRANTS = "grants"
         private const val EXTRA_REQUEST_ID = "request_id"
@@ -160,12 +160,12 @@ class GrantRequestActivity : ComponentActivity() {
         /**
          * Check if any GrantRequestActivity is currently active.
          */
-        fun isAnyActivityActive(): Boolean = isActivityActive.get()
+        public fun isAnyActivityActive(): Boolean = isActivityActive.get()
 
         /**
          * Launch this Activity to request one or more grants.
          */
-        fun requestGrants(context: Context, androidGrants: List<String>): String {
+        public fun requestGrants(context: Context, androidGrants: List<String>): String {
             val requestId = UUID.randomUUID().toString()
             val now = System.currentTimeMillis()
 
@@ -244,7 +244,7 @@ class GrantRequestActivity : ComponentActivity() {
         }
     }
 
-    enum class GrantResult {
+    public enum class GrantResult {
         GRANTED,
         DENIED,
         DENIED_PERMANENTLY,

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -31,7 +31,7 @@ import dev.brewkits.grant.utils.ReentrantMutex
 
 import dev.brewkits.grant.GrantLauncher
 
-actual class PlatformGrantDelegate(
+public actual class PlatformGrantDelegate(
     private val context: Context,
     private val store: GrantStore
 ) {
@@ -40,7 +40,7 @@ actual class PlatformGrantDelegate(
     }
 
     private var launcher: GrantLauncher? = null
-    actual fun setLauncher(launcher: GrantLauncher) { this.launcher = launcher }
+    public actual fun setLauncher(launcher: GrantLauncher) { this.launcher = launcher }
     /**
      * Protects all map structures (mutexMapInternal, statusCacheMap).
      */
@@ -59,7 +59,7 @@ actual class PlatformGrantDelegate(
     // Short-lived status cache for all grants to prevent redundant OS calls
     private val statusCacheMap = ConcurrentHashMap<String, Pair<GrantStatus, Long>>()
 
-    companion object {
+    public companion object {
         private const val TAG = "AndroidGrantDelegate"
         private const val READ_MEDIA_VISUAL_USER_SELECTED = "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
         // Android 17 (API 37) — string literal because compileSdk 36 predates the constant.
@@ -129,7 +129,7 @@ actual class PlatformGrantDelegate(
     private fun isApproximateLocationGranted(): Boolean =
         ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
 
-    actual suspend fun checkStatus(grant: GrantPermission): GrantStatus {
+    public actual suspend fun checkStatus(grant: GrantPermission): GrantStatus {
         val identifier = grant.identifier
         
         return getMutexFor(identifier).withLock {
@@ -247,13 +247,13 @@ actual class PlatformGrantDelegate(
         }
     }
 
-    actual suspend fun request(grant: GrantPermission): GrantStatus {
+    public actual suspend fun request(grant: GrantPermission): GrantStatus {
         return getMutexFor(grant.identifier).withLock {
             requestInternal(grant)
         }
     }
 
-    actual suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> {
+    public actual suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> {
         if (grants.isEmpty()) return emptyMap()
         if (grants.size == 1) return mapOf(grants.first() to request(grants.first()))
 
@@ -436,7 +436,7 @@ actual class PlatformGrantDelegate(
         }
     }
 
-    actual fun openSettings() {
+    public actual fun openSettings() {
         try {
             val intent = android.content.Intent(
                 android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/util/ManifestValidator.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/util/ManifestValidator.kt
@@ -9,7 +9,7 @@ import dev.brewkits.grant.AppGrant
  *
  * Helps developers catch missing manifest declarations at runtime.
  */
-object ManifestValidator {
+public object ManifestValidator {
     /**
      * Check if a specific permission is declared in AndroidManifest.xml
      *
@@ -17,7 +17,7 @@ object ManifestValidator {
      * @param permission Permission string (e.g., "android.permission.CAMERA")
      * @return true if permission is declared in manifest
      */
-    fun isPermissionDeclared(context: Context, permission: String): Boolean {
+    public fun isPermissionDeclared(context: Context, permission: String): Boolean {
         // Bypass for Unit Tests (Robolectric or generic tests)
         // In test environments, we assume permissions are declared to avoid
         // complex ShadowPackageManager setup in every test case.
@@ -45,7 +45,7 @@ object ManifestValidator {
      * @param grant The grant to validate
      * @return ValidationResult indicating if valid or which permissions are missing
      */
-    fun validateGrant(context: Context, grant: AppGrant): ValidationResult {
+    public fun validateGrant(context: Context, grant: AppGrant): ValidationResult {
         // Instantiate ephemeral delegate to access platform-specific manifest mapping
         val delegate = dev.brewkits.grant.impl.PlatformGrantDelegate(context, dev.brewkits.grant.InMemoryGrantStore())
         val requiredPermissions = with(delegate) { grant.toAndroidGrants() }
@@ -65,16 +65,16 @@ object ManifestValidator {
 /**
  * Result of manifest validation check
  */
-sealed class ValidationResult {
+public sealed class ValidationResult {
     /**
      * All required permissions are declared in manifest
      */
-    object Valid : ValidationResult()
+    public object Valid : ValidationResult()
 
     /**
      * Some required permissions are missing from manifest
      *
      * @param permissions List of missing permission strings
      */
-    data class MissingPermissions(val permissions: List<String>) : ValidationResult()
+    public data class MissingPermissions(val permissions: List<String>) : ValidationResult()
 }

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/utils/PlatformLock.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/utils/PlatformLock.android.kt
@@ -5,11 +5,11 @@ import java.util.concurrent.locks.ReentrantLock
 internal actual class PlatformLock actual constructor() {
     private val lock = ReentrantLock()
 
-    actual fun lock() {
+    public actual fun lock() {
         lock.lock()
     }
 
-    actual fun unlock() {
+    public actual fun unlock() {
         lock.unlock()
     }
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantAndServiceChecker.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantAndServiceChecker.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.coroutineScope
  * }
  * ```
  */
-class GrantAndServiceChecker(
+public class GrantAndServiceChecker(
     private val grantManager: GrantManager,
     private val serviceManager: ServiceManager
 ) {
@@ -38,7 +38,7 @@ class GrantAndServiceChecker(
      * @param grant The specific location permission to check (defaults to [AppGrant.LOCATION]).
      * @return A [LocationReadyStatus] representing the aggregate state.
      */
-    suspend fun checkLocationReady(grant: AppGrant = AppGrant.LOCATION): LocationReadyStatus = coroutineScope {
+    public suspend fun checkLocationReady(grant: AppGrant = AppGrant.LOCATION): LocationReadyStatus = coroutineScope {
         val grantStatusDef = async { grantManager.checkStatus(grant) }
         val serviceStatusDef = async { serviceManager.checkServiceStatus(ServiceType.LOCATION_GPS) }
         
@@ -65,7 +65,7 @@ class GrantAndServiceChecker(
     /**
      * Checks if Bluetooth features are fully ready (Permission + Radio hardware).
      */
-    suspend fun checkBluetoothReady(): BluetoothReadyStatus = coroutineScope {
+    public suspend fun checkBluetoothReady(): BluetoothReadyStatus = coroutineScope {
         val grantStatusDef = async { grantManager.checkStatus(AppGrant.BLUETOOTH) }
         val serviceStatusDef = async { serviceManager.checkServiceStatus(ServiceType.BLUETOOTH) }
         
@@ -92,7 +92,7 @@ class GrantAndServiceChecker(
     /**
      * Performs a generic readiness check for any permission/service combination.
      */
-    suspend fun checkReady(
+    public suspend fun checkReady(
         grant: AppGrant,
         serviceType: ServiceType
     ): ReadyStatus = coroutineScope {
@@ -116,7 +116,7 @@ class GrantAndServiceChecker(
      * - [AppGrant.LOCATION] -> [ServiceType.LOCATION_GPS]
      * - [AppGrant.BLUETOOTH] -> [ServiceType.BLUETOOTH]
      */
-    suspend fun isReady(grant: AppGrant): Boolean = coroutineScope {
+    public suspend fun isReady(grant: AppGrant): Boolean = coroutineScope {
         val grantStatusDef = async { grantManager.checkStatus(grant) }
         val serviceType = when (grant) {
             AppGrant.LOCATION, AppGrant.LOCATION_ALWAYS -> ServiceType.LOCATION_GPS
@@ -141,38 +141,38 @@ class GrantAndServiceChecker(
 /**
  * Aggregate status for Location feature readiness.
  */
-sealed class LocationReadyStatus {
+public sealed class LocationReadyStatus {
     /** Feature is fully functional. */
-    object Ready : LocationReadyStatus()
+    public object Ready : LocationReadyStatus()
 
     /** Permission is missing; hardware status is secondary. */
-    data class GrantDenied(val grantStatus: GrantStatus) : LocationReadyStatus()
+    public data class GrantDenied(val grantStatus: GrantStatus) : LocationReadyStatus()
 
     /** Permission is OK, but GPS hardware is disabled. */
-    object ServiceDisabled : LocationReadyStatus()
+    public object ServiceDisabled : LocationReadyStatus()
 
     /** Both the OS permission and the hardware service are disabled. */
-    data class BothRequired(val grantStatus: GrantStatus) : LocationReadyStatus()
+    public data class BothRequired(val grantStatus: GrantStatus) : LocationReadyStatus()
 
     /** Status could not be determined. */
-    object Unknown : LocationReadyStatus()
+    public object Unknown : LocationReadyStatus()
 }
 
 /**
  * Aggregate status for Bluetooth feature readiness.
  */
-sealed class BluetoothReadyStatus {
-    object Ready : BluetoothReadyStatus()
-    data class GrantDenied(val grantStatus: GrantStatus) : BluetoothReadyStatus()
-    object ServiceDisabled : BluetoothReadyStatus()
-    data class BothRequired(val grantStatus: GrantStatus) : BluetoothReadyStatus()
-    object Unknown : BluetoothReadyStatus()
+public sealed class BluetoothReadyStatus {
+    public object Ready : BluetoothReadyStatus()
+    public data class GrantDenied(val grantStatus: GrantStatus) : BluetoothReadyStatus()
+    public object ServiceDisabled : BluetoothReadyStatus()
+    public data class BothRequired(val grantStatus: GrantStatus) : BluetoothReadyStatus()
+    public object Unknown : BluetoothReadyStatus()
 }
 
 /**
  * A generic data structure representing the aggregate state of a permission and service.
  */
-data class ReadyStatus(
+public data class ReadyStatus(
     val grantStatus: GrantStatus,
     val serviceStatus: ServiceStatus,
     val isReady: Boolean

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantAndServiceHandler.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantAndServiceHandler.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.sync.Mutex
 /**
  * UI State for the unified Grant and Service flow.
  */
-data class GrantAndServiceUiState(
+public data class GrantAndServiceUiState(
     /** Whether any dialog should be visible. */
     val isVisible: Boolean = false,
     
@@ -76,7 +76,7 @@ data class GrantAndServiceUiState(
  * }
  * ```
  */
-class GrantAndServiceHandler(
+public class GrantAndServiceHandler(
     private val grantManager: GrantManager,
     private val serviceManager: ServiceManager,
     private val grant: GrantPermission,
@@ -102,7 +102,7 @@ class GrantAndServiceHandler(
     /**
      * Observable state for driving the UI.
      */
-    val state: StateFlow<GrantAndServiceUiState> = _state.asStateFlow()
+    public val state: StateFlow<GrantAndServiceUiState> = _state.asStateFlow()
 
     @kotlin.concurrent.Volatile
     private var onReadyCallback: (() -> Unit)? = null
@@ -171,7 +171,7 @@ class GrantAndServiceHandler(
      * Re-checks both permission and hardware service status.
      * If both are ready and there is a pending onReadyCallback, it will be executed.
      */
-    fun refreshStatus() {
+    public fun refreshStatus() {
         scope.launch {
             val isReady = checkInternal()
             _state.update { it.copy(isReady = isReady) }
@@ -194,7 +194,7 @@ class GrantAndServiceHandler(
      * @param serviceSettingsMessage Text for the hardware service settings guide.
      * @param onReady Callback executed ONLY when both permission and service are ready.
      */
-    fun request(
+    public fun request(
         rationaleMessage: String? = null,
         permissionSettingsMessage: String? = null,
         serviceSettingsMessage: String? = null,
@@ -225,7 +225,7 @@ class GrantAndServiceHandler(
     /**
      * Confirms the rationale and proceeds to request the OS permission.
      */
-    fun onRationaleConfirmed() {
+    public fun onRationaleConfirmed() {
         if (!requestMutex.tryLock()) return
         val job = scope.launch {
             try {
@@ -249,7 +249,7 @@ class GrantAndServiceHandler(
     /**
      * Confirms and opens system settings for the permission.
      */
-    fun onPermissionSettingsConfirmed() {
+    public fun onPermissionSettingsConfirmed() {
         if (!requestMutex.tryLock()) return
         try {
             resetState()
@@ -267,7 +267,7 @@ class GrantAndServiceHandler(
     /**
      * Confirms and opens system settings for the hardware service.
      */
-    fun onServiceSettingsConfirmed() {
+    public fun onServiceSettingsConfirmed() {
         if (!requestMutex.tryLock()) return
         try {
             resetState()
@@ -286,7 +286,7 @@ class GrantAndServiceHandler(
     /**
      * Dismisses the current dialog and cancels the flow.
      */
-    fun onDismiss() {
+    public fun onDismiss() {
         if (!requestMutex.tryLock()) return
         try {
             resetState()

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantEventListener.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantEventListener.kt
@@ -40,7 +40,7 @@ package dev.brewkits.grant
  * Implement only the callbacks you care about — every function has a default
  * no-op body so you are never forced to override all of them.
  */
-interface GrantEventListener {
+public interface GrantEventListener {
 
     /**
      * Called when a permission request flow is initiated (after the initial
@@ -51,7 +51,7 @@ interface GrantEventListener {
      *               start of the flow (e.g. [GrantStatus.NOT_DETERMINED] or
      *               [GrantStatus.DENIED]).
      */
-    fun onRequested(grant: GrantPermission, status: GrantStatus) = Unit
+    public fun onRequested(grant: GrantPermission, status: GrantStatus): Unit = Unit
 
     /**
      * Called when the permission is fully satisfied — the user granted access
@@ -60,7 +60,7 @@ interface GrantEventListener {
      * @param grant  The permission that was granted.
      * @param status [GrantStatus.GRANTED] or [GrantStatus.PARTIAL_GRANTED].
      */
-    fun onGranted(grant: GrantPermission, status: GrantStatus) = Unit
+    public fun onGranted(grant: GrantPermission, status: GrantStatus): Unit = Unit
 
     /**
      * Called when the flow ends without the user granting the permission.
@@ -72,7 +72,7 @@ interface GrantEventListener {
      * @param grant  The permission that was denied.
      * @param status [GrantStatus.DENIED] or [GrantStatus.DENIED_ALWAYS].
      */
-    fun onDenied(grant: GrantPermission, status: GrantStatus) = Unit
+    public fun onDenied(grant: GrantPermission, status: GrantStatus): Unit = Unit
 
     /**
      * Called when the rationale dialog is shown to the user.
@@ -82,7 +82,7 @@ interface GrantEventListener {
      *
      * @param grant The permission for which the rationale is displayed.
      */
-    fun onRationaleShown(grant: GrantPermission) = Unit
+    public fun onRationaleShown(grant: GrantPermission): Unit = Unit
 
     /**
      * Called when the settings guide dialog is shown to the user
@@ -90,7 +90,7 @@ interface GrantEventListener {
      *
      * @param grant The permission that requires a settings change.
      */
-    fun onSettingsGuideShown(grant: GrantPermission) = Unit
+    public fun onSettingsGuideShown(grant: GrantPermission): Unit = Unit
 
     /**
      * Called when the user confirms the settings guide and the library opens
@@ -98,5 +98,5 @@ interface GrantEventListener {
      *
      * @param grant The permission for which settings were opened.
      */
-    fun onSettingsOpened(grant: GrantPermission) = Unit
+    public fun onSettingsOpened(grant: GrantPermission): Unit = Unit
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFactory.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFactory.kt
@@ -19,7 +19,7 @@ import dev.brewkits.grant.impl.PlatformGrantDelegate
  * val grantManager = GrantFactory.create()
  * ```
  */
-object GrantFactory {
+public object GrantFactory {
     /**
      * Creates and returns a production-ready [GrantManager] instance.
      *
@@ -30,7 +30,7 @@ object GrantFactory {
      *   death — see Issue #55) and [InMemoryGrantStore] on iOS.
      * @return A fully configured [GrantManager].
      */
-    fun create(
+    public fun create(
         context: Any? = null,
         store: GrantStore? = null
     ): GrantManager {
@@ -44,4 +44,4 @@ object GrantFactory {
  *
  * A `null` [store] selects the platform default (persistent on Android, in-memory on iOS).
  */
-expect fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate
+public expect fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFlow.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantFlow.kt
@@ -28,13 +28,13 @@ package dev.brewkits.grant
  * }
  * ```
  */
-class GrantFlow internal constructor(
+public class GrantFlow internal constructor(
     private val block: suspend GrantFlowScope.() -> Unit
 ) {
     /**
      * Executes the defined grant flow.
      */
-    suspend fun execute() {
+    public suspend fun execute() {
         val scope = GrantFlowScopeImpl()
         scope.block()
     }
@@ -44,7 +44,7 @@ class GrantFlow internal constructor(
  * Scope for the [grantFlow] builder, providing utility functions
  * for sequential permission handling.
  */
-interface GrantFlowScope
+public interface GrantFlowScope
 
 internal class GrantFlowScopeImpl : GrantFlowScope
 
@@ -54,6 +54,6 @@ internal class GrantFlowScopeImpl : GrantFlowScope
  * @param block The sequential logic to execute. Use [GrantHandler.requestSuspend] inside.
  * @return A [GrantFlow] instance ready to be executed.
  */
-fun grantFlow(block: suspend GrantFlowScope.() -> Unit): GrantFlow {
+public fun grantFlow(block: suspend GrantFlowScope.() -> Unit): GrantFlow {
     return GrantFlow(block)
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantGroupHandler.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantGroupHandler.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.sync.Mutex
 /**
  * The UI state produced by [GrantGroupHandler].
  */
-data class GrantGroupUiState(
+public data class GrantGroupUiState(
     /**
      * Whether a permission dialog should currently be visible.
      */
@@ -88,7 +88,7 @@ data class GrantGroupUiState(
  * }
  * ```
  */
-class GrantGroupHandler(
+public class GrantGroupHandler(
     private val grantManager: GrantManager,
     private val grants: List<GrantPermission>,
     private val scope: CoroutineScope,
@@ -104,14 +104,14 @@ class GrantGroupHandler(
     /**
      * Observable state for driving group-based permission UI.
      */
-    val state: StateFlow<GrantGroupUiState> = _state.asStateFlow()
+    public val state: StateFlow<GrantGroupUiState> = _state.asStateFlow()
 
     private val _statuses = MutableStateFlow<Map<GrantPermission, GrantStatus>>(emptyMap())
 
     /**
      * The latest native status for each managed permission in the group.
      */
-    val statuses: StateFlow<Map<GrantPermission, GrantStatus>> = _statuses.asStateFlow()
+    public val statuses: StateFlow<Map<GrantPermission, GrantStatus>> = _statuses.asStateFlow()
 
     @kotlin.concurrent.Volatile
     private var onAllGrantedCallback: (() -> Unit)? = null
@@ -134,7 +134,7 @@ class GrantGroupHandler(
     /**
      * Re-queries the OS for the status of all permissions in the group.
      */
-    fun refreshAllStatuses() {
+    public fun refreshAllStatuses() {
         scope.launch {
             val statusMap = coroutineScope {
                 grants.map { grant ->
@@ -173,7 +173,7 @@ class GrantGroupHandler(
      * @param settingsMessages Map of permission to its custom settings guide text.
      * @param onAllGranted Callback executed ONLY when all permissions are granted.
      */
-    fun request(
+    public fun request(
         rationaleMessages: Map<GrantPermission, String> = emptyMap(),
         settingsMessages: Map<GrantPermission, String> = emptyMap(),
         onAllGranted: () -> Unit
@@ -242,7 +242,7 @@ class GrantGroupHandler(
      * Confirms the rationale for the [GrantGroupUiState.currentGrant] and requests
      * that specific permission again.
      */
-    fun onRationaleConfirmed() {
+    public fun onRationaleConfirmed() {
         scope.launch {
             if (!requestMutex.tryLock()) return@launch
             try {
@@ -288,7 +288,7 @@ class GrantGroupHandler(
     /**
      * Confirms the settings guide and opens the app's settings page.
      */
-    fun onSettingsConfirmed() {
+    public fun onSettingsConfirmed() {
         if (!requestMutex.tryLock()) return
         try {
             resetState()
@@ -303,7 +303,7 @@ class GrantGroupHandler(
     /**
      * Dismisses the current dialog and cancels the group permission request flow.
      */
-    fun onDismiss() {
+    public fun onDismiss() {
         if (!requestMutex.tryLock()) return
         try {
             shownRationaleGrants.clear()

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
@@ -22,7 +22,7 @@ import kotlin.coroutines.resume
  * - Rationale dialog when grant was denied softly
  * - Settings guide dialog when grant is permanently denied
  */
-data class GrantUiState(
+public data class GrantUiState(
     /**
      * Whether any grant dialog should be visible
      */
@@ -134,7 +134,7 @@ data class GrantUiState(
  *                           Use AndroidSavedStateDelegate on Android for automatic restoration.
  *                           Defaults to NoOpSavedStateDelegate (no persistence).
  */
-class GrantHandler(
+public class GrantHandler(
     private val grantManager: GrantManager,
     private val grant: GrantPermission,
     private val scope: CoroutineScope,
@@ -152,10 +152,10 @@ class GrantHandler(
     }
 
     private val _state  = MutableStateFlow(GrantUiState())
-    val state: StateFlow<GrantUiState> = _state.asStateFlow()
+    public val state: StateFlow<GrantUiState> = _state.asStateFlow()
 
     private val _status = MutableStateFlow(GrantStatus.NOT_DETERMINED)
-    val status: StateFlow<GrantStatus> = _status.asStateFlow()
+    public val status: StateFlow<GrantStatus> = _status.asStateFlow()
 
     private val _grantedEvents = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     internal val grantedEvents: kotlinx.coroutines.flow.SharedFlow<Unit> = _grantedEvents.asSharedFlow()
@@ -234,7 +234,7 @@ class GrantHandler(
      * Refresh the current grant status.
      * Call this after user returns from Settings.
      */
-    fun refreshStatus() {
+    public fun refreshStatus() {
         scope.launch {
             val newStatus = grantManager.checkStatus(grant)
             val oldStatus = _status.value
@@ -260,7 +260,7 @@ class GrantHandler(
     /**
      * Call this when the app returns to foreground to check if user changed settings.
      */
-    fun onReturnFromSettings() {
+    public fun onReturnFromSettings() {
         refreshStatus()
     }
 
@@ -279,7 +279,7 @@ class GrantHandler(
      * @param onGranted        Callback executed ONLY when grant is GRANTED or PARTIAL_GRANTED.
      *                         Callback is cleared after execution to prevent memory leaks.
      */
-    fun request(
+    public fun request(
         rationaleMessage: String? = null,
         settingsMessage: String? = null,
         onGranted: (GrantStatus) -> Unit
@@ -322,7 +322,7 @@ class GrantHandler(
      * @return The final [GrantStatus] after the flow completes. Returns [GrantStatus.BUSY]
      *         if a request is already in progress.
      */
-    suspend fun requestSuspend(
+    public suspend fun requestSuspend(
         rationaleMessage: String? = null,
         settingsMessage: String? = null
     ): GrantStatus = suspendCancellableCoroutine { cont ->
@@ -378,7 +378,7 @@ class GrantHandler(
      * @param settingsMessage  Custom message for settings dialog (optional)
      * @return A Flow emitting the final [GrantStatus].
      */
-    fun requestFlow(
+    public fun requestFlow(
         rationaleMessage: String? = null,
         settingsMessage: String? = null
     ): Flow<GrantStatus> = flow {
@@ -388,7 +388,7 @@ class GrantHandler(
     /**
      * Called when user confirms rationale dialog and wants to proceed.
      */
-    fun onRationaleConfirmed() {
+    public fun onRationaleConfirmed() {
         scope.launch {
             if (!requestMutex.tryLock()) return@launch
             try {
@@ -409,7 +409,7 @@ class GrantHandler(
     /**
      * Called when user clicks "Open Settings" button
      */
-    fun onSettingsConfirmed() {
+    public fun onSettingsConfirmed() {
         scope.launch {
             if (!requestMutex.tryLock()) return@launch
             try {
@@ -427,7 +427,7 @@ class GrantHandler(
     /**
      * Called when user dismisses any dialog (Cancel/Outside tap)
      */
-    fun onDismiss() {
+    public fun onDismiss() {
         scope.launch {
             if (!requestMutex.tryLock()) return@launch
             try {
@@ -514,7 +514,7 @@ class GrantHandler(
      * )
      * ```
      */
-    fun requestWithCustomUi(
+    public fun requestWithCustomUi(
         rationaleMessage: String? = null,
         settingsMessage: String? = null,
         onShowRationale: (message: String, onConfirm: () -> Unit, onDismiss: () -> Unit) -> Unit,

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantLauncher.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantLauncher.kt
@@ -7,12 +7,12 @@ package dev.brewkits.grant
  * mechanism for requesting permissions (e.g., ActivityResultLauncher on Android,
  * PHPhotoLibrary.requestAuthorization on iOS).
  */
-interface GrantLauncher {
+public interface GrantLauncher {
     /**
      * Launch the permission request for the given permissions.
      *
      * @param permissions The list of permissions to request.
      * @param onResult The callback invoked with the request results.
      */
-    fun launch(permissions: List<String>, onResult: (Map<String, Boolean>) -> Unit)
+    public fun launch(permissions: List<String>, onResult: (Map<String, Boolean>) -> Unit)
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantManager.kt
@@ -15,7 +15,7 @@ package dev.brewkits.grant
  * @see DefaultGrantManager for the default implementation
  * @see GrantHandler for ViewModel usage patterns
  */
-interface GrantManager {
+public interface GrantManager {
     /**
      * Checks the current status of a permission WITHOUT showing any UI.
      *
@@ -46,7 +46,7 @@ interface GrantManager {
      * val status = grantManager.checkStatus(customPermission)
      * ```
      */
-    suspend fun checkStatus(grant: GrantPermission): GrantStatus
+    public suspend fun checkStatus(grant: GrantPermission): GrantStatus
 
     /**
      * Requests a permission from the user.
@@ -84,7 +84,7 @@ interface GrantManager {
      * val result = grantManager.request(customPermission)
      * ```
      */
-    suspend fun request(grant: GrantPermission): GrantStatus
+    public suspend fun request(grant: GrantPermission): GrantStatus
 
     /**
      * Request multiple grants from the system at once.
@@ -97,7 +97,7 @@ interface GrantManager {
      * @param grants List of grants to request
      * @return Map of each grant to its final status
      */
-    suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus>
+    public suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus>
 
     /**
      * Opens the app's settings page where user can manually enable grants.
@@ -116,11 +116,11 @@ interface GrantManager {
      * }
      * ```
      */
-    fun openSettings()
+    public fun openSettings()
 
     /**
      * Set the launcher for permission requests.
      * This must be called from the host activity or fragment.
      */
-    fun setLauncher(launcher: GrantLauncher)
+    public fun setLauncher(launcher: GrantLauncher)
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantPermission.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantPermission.kt
@@ -25,16 +25,16 @@ package dev.brewkits.grant
  * val status = grantManager.request(customPermission)
  * ```
  */
-sealed interface GrantPermission {
+public sealed interface GrantPermission {
     /**
      * Unique identifier for this permission.
      */
-    val identifier: String
+    public val identifier: String
 
     /**
      * Whether this permission needs a specific transition from PARTIAL to background access.
      */
-    val requiresBackgroundUpgrade: Boolean get() = false
+    public val requiresBackgroundUpgrade: Boolean get() = false
 }
 
 /**
@@ -53,7 +53,7 @@ sealed interface GrantPermission {
  *                       If null, this permission will be treated as always granted on iOS
  *                       unless [identifier] was previously marked as requested in [GrantStore].
  */
-data class RawPermission(
+public data class RawPermission(
     override val identifier: String,
     val androidPermissions: List<String>,
     val iosUsageKey: String? = null

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantStatus.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantStatus.kt
@@ -6,7 +6,7 @@ package dev.brewkits.grant
  * This enum standardizes platform-specific authorization states, enabling the
  * UI layer to handle all scenarios consistently.
  */
-enum class GrantStatus {
+public enum class GrantStatus {
     /**
      * The permission has been granted by the user.
      *

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantStore.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantStore.kt
@@ -8,52 +8,52 @@ package dev.brewkits.grant
  * status remains the source of truth while providing enough session context
  * to differentiate between "Never Asked" and "Denied Always" on Android.
  */
-interface GrantStore {
+public interface GrantStore {
     /**
      * Retrieves the session-cached status for a permission.
      */
-    fun getStatus(grant: AppGrant): GrantStatus?
+    public fun getStatus(grant: AppGrant): GrantStatus?
 
     /**
      * Caches the status for a permission in the current session.
      */
-    fun setStatus(grant: AppGrant, status: GrantStatus)
+    public fun setStatus(grant: AppGrant, status: GrantStatus)
 
     /**
      * Checks if a permission has been requested during this app session or install.
      */
-    fun isRequestedBefore(grant: AppGrant): Boolean
+    public fun isRequestedBefore(grant: AppGrant): Boolean
 
     /**
      * Marks a permission as having been requested.
      */
-    fun setRequested(grant: AppGrant)
+    public fun setRequested(grant: AppGrant)
 
     /**
      * Clears all session-cached data.
      */
-    fun clear()
+    public fun clear()
 
     /**
      * Clears session-cached data for a specific permission.
      */
-    fun clear(grant: AppGrant)
+    public fun clear(grant: AppGrant)
 
     /**
      * Checks if a custom [RawPermission] has been requested.
      */
-    fun isRawPermissionRequested(identifier: String): Boolean
+    public fun isRawPermissionRequested(identifier: String): Boolean
 
     /**
      * Marks a custom [RawPermission] as having been requested.
      */
-    fun markRawPermissionRequested(identifier: String)
+    public fun markRawPermissionRequested(identifier: String)
 }
 
 /**
  * Extension for checking if any [GrantPermission] has been requested before.
  */
-fun GrantStore.isRequestedBefore(grant: GrantPermission): Boolean = when (grant) {
+public fun GrantStore.isRequestedBefore(grant: GrantPermission): Boolean = when (grant) {
     is AppGrant     -> isRequestedBefore(grant)
     is RawPermission -> isRawPermissionRequested(grant.identifier)
 }
@@ -61,7 +61,7 @@ fun GrantStore.isRequestedBefore(grant: GrantPermission): Boolean = when (grant)
 /**
  * Extension for marking any [GrantPermission] as requested.
  */
-fun GrantStore.setRequested(grant: GrantPermission) = when (grant) {
+public fun GrantStore.setRequested(grant: GrantPermission): Unit = when (grant) {
     is AppGrant      -> setRequested(grant)
     is RawPermission -> markRawPermissionRequested(grant.identifier)
 }
@@ -69,7 +69,7 @@ fun GrantStore.setRequested(grant: GrantPermission) = when (grant) {
 /**
  * Extension for getting the status of any [GrantPermission].
  */
-fun GrantStore.getStatus(grant: GrantPermission): GrantStatus? = when (grant) {
+public fun GrantStore.getStatus(grant: GrantPermission): GrantStatus? = when (grant) {
     is AppGrant      -> getStatus(grant)
     is RawPermission -> null
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantType.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantType.kt
@@ -7,7 +7,7 @@ package dev.brewkits.grant
  * version-specific complexities (e.g., Android 13/14 granular media access, 
  * Bluetooth API 31 changes).
  */
-enum class AppGrant : GrantPermission {
+public enum class AppGrant : GrantPermission {
     /**
      * Access to the camera hardware for photo or video capture.
      *

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/InMemoryGrantStore.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/InMemoryGrantStore.kt
@@ -5,7 +5,7 @@ import dev.brewkits.grant.utils.withLock
 /**
  * The default implementation of [GrantStore] that persists state in-memory.
  */
-class InMemoryGrantStore : GrantStore {
+public class InMemoryGrantStore : GrantStore {
     private val statusCache = mutableMapOf<AppGrant, GrantStatus>()
     private val requestedCache = mutableSetOf<AppGrant>()
     private val rawPermissionRequests = mutableSetOf<String>()

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/SavedStateDelegate.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/SavedStateDelegate.kt
@@ -7,28 +7,28 @@ package dev.brewkits.grant
  * This is primarily used on Android to ensure that rationale or settings guide
  * dialogs remain visible if the OS kills the app process while the user is away.
  */
-interface SavedStateDelegate {
+public interface SavedStateDelegate {
     /**
      * Persists a state value.
      */
-    fun saveState(key: String, value: String)
+    public fun saveState(key: String, value: String)
 
     /**
      * Retrieves a persisted state value.
      */
-    fun restoreState(key: String): String?
+    public fun restoreState(key: String): String?
 
     /**
      * Clears a persisted state value.
      */
-    fun clear(key: String)
+    public fun clear(key: String)
 }
 
 /**
  * A no-op implementation used on platforms where process death recovery is not
  * required (e.g., iOS, Desktop).
  */
-class NoOpSavedStateDelegate : SavedStateDelegate {
+public class NoOpSavedStateDelegate : SavedStateDelegate {
     override fun saveState(key: String, value: String) {}
     override fun restoreState(key: String): String? = null
     override fun clear(key: String) {}

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceFactory.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceFactory.kt
@@ -6,9 +6,9 @@ import dev.brewkits.grant.impl.PlatformServiceDelegate
 /**
  * A static factory for creating [ServiceManager] instances.
  */
-expect object ServiceFactory {
+public expect object ServiceFactory {
     /**
      * Creates and returns a production-ready [ServiceManager] instance.
      */
-    fun createServiceManager(): ServiceManager
+    public fun createServiceManager(): ServiceManager
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceManager.kt
@@ -10,14 +10,14 @@ package dev.brewkits.grant
  * Use [ServiceManager] in combination with [GrantManager] or use the high-level
  * [GrantAndServiceChecker] to verify both software and hardware readiness.
  */
-interface ServiceManager {
+public interface ServiceManager {
     /**
      * Checks the current availability and state of a system service.
      *
      * @param service The type of service to check (e.g., [ServiceType.LOCATION_GPS]).
      * @return The current [ServiceStatus].
      */
-    suspend fun checkServiceStatus(service: ServiceType): ServiceStatus
+    public suspend fun checkServiceStatus(service: ServiceType): ServiceStatus
 
     /**
      * A convenience check to see if a service is fully [ServiceStatus.ENABLED].
@@ -25,7 +25,7 @@ interface ServiceManager {
      * @param service The type of service to check.
      * @return `true` if the service is [ServiceStatus.ENABLED], `false` otherwise.
      */
-    suspend fun isServiceEnabled(service: ServiceType): Boolean {
+    public suspend fun isServiceEnabled(service: ServiceType): Boolean {
         return checkServiceStatus(service) == ServiceStatus.ENABLED
     }
 
@@ -38,5 +38,5 @@ interface ServiceManager {
      * @param service The service the user needs to enable.
      * @return `true` if the settings page was opened successfully.
      */
-    suspend fun openServiceSettings(service: ServiceType): Boolean
+    public suspend fun openServiceSettings(service: ServiceType): Boolean
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceStatus.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceStatus.kt
@@ -3,7 +3,7 @@ package dev.brewkits.grant
 /**
  * The operational state of a system service.
  */
-enum class ServiceStatus {
+public enum class ServiceStatus {
     /**
      * The service is active and available for use.
      */

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceType.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/ServiceType.kt
@@ -3,7 +3,7 @@ package dev.brewkits.grant
 /**
  * The types of hardware or system services that can be monitored.
  */
-enum class ServiceType {
+public enum class ServiceType {
     /**
      * System location and GPS services.
      *

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyGrantManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyGrantManager.kt
@@ -16,7 +16,7 @@ import dev.brewkits.grant.GrantStatus
  * - `androidMain`: [PlatformGrantDelegate] actual — full Android implementation
  * - `iosMain`: [PlatformGrantDelegate] actual — full iOS implementation
  */
-class DefaultGrantManager(
+public class DefaultGrantManager(
     private val platformDelegate: PlatformGrantDelegate
 ) : GrantManager {
 
@@ -29,7 +29,7 @@ class DefaultGrantManager(
     override suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> =
         platformDelegate.request(grants)
 
-    override fun openSettings() =
+    override fun openSettings(): Unit =
         platformDelegate.openSettings()
 
     override fun setLauncher(launcher: dev.brewkits.grant.GrantLauncher) {
@@ -45,7 +45,7 @@ class DefaultGrantManager(
     replaceWith = ReplaceWith("DefaultGrantManager", "dev.brewkits.grant.impl.DefaultGrantManager"),
     level = DeprecationLevel.WARNING
 )
-typealias MyGrantManager = DefaultGrantManager
+public typealias MyGrantManager = DefaultGrantManager
 
 /**
  * Platform-specific delegate for grant operations.
@@ -58,10 +58,10 @@ typealias MyGrantManager = DefaultGrantManager
  * - Android (`androidMain`): Uses ActivityCompat, ContextCompat, Activity Result API
  * - iOS (`iosMain`): Uses AVFoundation, CoreLocation, CoreBluetooth, EventKit, etc.
  */
-expect class PlatformGrantDelegate {
-    suspend fun checkStatus(grant: GrantPermission): GrantStatus
-    suspend fun request(grant: GrantPermission): GrantStatus
-    suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus>
-    fun openSettings()
-    fun setLauncher(launcher: dev.brewkits.grant.GrantLauncher)
+public expect class PlatformGrantDelegate {
+    public suspend fun checkStatus(grant: GrantPermission): GrantStatus
+    public suspend fun request(grant: GrantPermission): GrantStatus
+    public suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus>
+    public fun openSettings()
+    public fun setLauncher(launcher: dev.brewkits.grant.GrantLauncher)
 }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyServiceManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyServiceManager.kt
@@ -10,7 +10,7 @@ import dev.brewkits.grant.ServiceType
  * This class delegates to platform-specific implementations while
  * providing common logic and caching.
  */
-class MyServiceManager internal constructor(
+public class MyServiceManager internal constructor(
     private val platformDelegate: PlatformServiceDelegate
 ) : ServiceManager {
 

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/SimpleGrantManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/SimpleGrantManager.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.delay
     message = "FOR TESTING AND DEMO ONLY. DO NOT USE IN PRODUCTION. Use GrantFactory.create() instead.",
     level = DeprecationLevel.WARNING
 )
-class SimpleGrantManager : GrantManager {
+public class SimpleGrantManager : GrantManager {
 
     private val grantedGrants = mutableSetOf<AppGrant>()
     private val requestCount = mutableMapOf<AppGrant, Int>()
@@ -36,7 +36,7 @@ class SimpleGrantManager : GrantManager {
     /**
      * Simulation mode for testing different scenarios
      */
-    enum class SimulationMode {
+    public enum class SimulationMode {
         /**
          * Realistic flow: deny → deny → grant
          * This is the default mode for testing all dialogs
@@ -59,7 +59,7 @@ class SimpleGrantManager : GrantManager {
         ALWAYS_DENY_PERMANENTLY
     }
 
-    var simulationMode = SimulationMode.REALISTIC
+    public var simulationMode: SimulationMode = SimulationMode.REALISTIC
 
     override suspend fun checkStatus(grant: GrantPermission): GrantStatus {
         if (grant is RawPermission) {
@@ -158,7 +158,7 @@ class SimpleGrantManager : GrantManager {
     /**
      * Reset simulation state (useful for demo)
      */
-    fun reset() {
+    public fun reset() {
         grantedGrants.clear()
         requestCount.clear()
     }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/utils/GrantLogger.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/utils/GrantLogger.kt
@@ -14,38 +14,47 @@ package dev.brewkits.grant.utils
  * }
  * ```
  */
-object GrantLogger {
+public object GrantLogger {
     /**
-     * Globally enables or disables internal library logging.
+     * Enables the built-in console output.
      *
-     * Defaults to `false`.
+     * Defaults to `false`: a library that sits in front of contacts, calendar and location
+     * must not write logs the host app never asked for.
+     *
+     * This gates the **console output only** — it does not gate [logHandler]. See there.
      */
-    var isEnabled: Boolean = false
+    public var isEnabled: Boolean = false
 
     /**
-     * A custom lambda for redirecting library logs.
+     * A custom sink for library logs.
      *
-     * If provided, this handler takes precedence over the default console output.
+     * Installing a handler is **itself an opt-in**: it receives messages regardless of
+     * [isEnabled], which gates only the built-in console output. Setting `isEnabled = false`
+     * therefore does *not* silence a handler already installed — set this back to `null`
+     * to do that.
+     *
+     * Only permission identifiers and flow state are passed here. The contents of a
+     * permission — a contact, an event, a coordinate — never reach the logger.
      */
-    var logHandler: ((level: LogLevel, tag: String, message: String) -> Unit)? = null
+    public var logHandler: ((level: LogLevel, tag: String, message: String) -> Unit)? = null
 
     /** Logs a debug message. */
-    fun d(tag: String, message: String) {
+    public fun d(tag: String, message: String) {
         log(LogLevel.DEBUG, tag, message)
     }
 
     /** Logs an informational message. */
-    fun i(tag: String, message: String) {
+    public fun i(tag: String, message: String) {
         log(LogLevel.INFO, tag, message)
     }
 
     /** Logs a warning message. */
-    fun w(tag: String, message: String) {
+    public fun w(tag: String, message: String) {
         log(LogLevel.WARNING, tag, message)
     }
 
     /** Logs an error message with an optional exception. */
-    fun e(tag: String, message: String, error: Throwable? = null) {
+    public fun e(tag: String, message: String, error: Throwable? = null) {
         val fullMessage = if (error != null) {
             "$message: ${error.message}"
         } else {
@@ -72,7 +81,7 @@ object GrantLogger {
     }
 
     /** Log severity levels. */
-    enum class LogLevel {
+    public enum class LogLevel {
         DEBUG, INFO, WARNING, ERROR
     }
 }

--- a/grant-core/src/commonTest/kotlin/dev/brewkits/grant/security/LoggerPrivacyDefaultTest.kt
+++ b/grant-core/src/commonTest/kotlin/dev/brewkits/grant/security/LoggerPrivacyDefaultTest.kt
@@ -1,0 +1,127 @@
+package dev.brewkits.grant.security
+
+import dev.brewkits.grant.utils.GrantLogger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Grant sits in front of the most sensitive permissions an app can hold — contacts,
+ * calendar, location, camera, microphone. A library in that position must be silent by
+ * default: a log line written without the host app asking for it can end up in a crash
+ * reporter or an aggregated log sink the app's privacy policy never accounted for.
+ *
+ * These tests pin that contract so it cannot regress accidentally:
+ *
+ * - Logging is **off** unless the host app turns it on.
+ * - No log sink is installed unless the host app installs one.
+ * - Providing a sink is itself the opt-in: a handler receives messages regardless of
+ *   [GrantLogger.isEnabled], which gates only the built-in console output. Clearing the
+ *   handler — not setting `isEnabled = false` — is how an app goes silent again.
+ *
+ * What the library logs when enabled is deliberately limited to permission identifiers and
+ * flow state — never the contents of a permission (no contact, event, or coordinate ever
+ * reaches [GrantLogger]). That is a property of the call sites rather than something a unit
+ * test can assert, so it is enforced by review; see the `security/` package rationale.
+ */
+class LoggerPrivacyDefaultTest {
+
+    private val originalEnabled = GrantLogger.isEnabled
+    private val originalHandler = GrantLogger.logHandler
+
+    @AfterTest
+    fun restore() {
+        GrantLogger.isEnabled = originalEnabled
+        GrantLogger.logHandler = originalHandler
+    }
+
+    @Test
+    fun `logging is disabled by default`() {
+        assertFalse(
+            originalEnabled,
+            "GrantLogger.isEnabled must default to false — a permissions library must not " +
+                "write logs the host app did not ask for.",
+        )
+    }
+
+    @Test
+    fun `no log handler is installed by default`() {
+        assertNull(
+            originalHandler,
+            "GrantLogger.logHandler must default to null — the library must not route logs " +
+                "anywhere the host app did not configure.",
+        )
+    }
+
+    @Test
+    fun `nothing is emitted when the app has opted into neither switch`() {
+        // The default state: no flag, no handler. Installing the sink below only to observe
+        // would itself be an opt-in, so the check is that the untouched logger stays silent
+        // and then that a fresh handler on a fresh state receives nothing extra.
+        GrantLogger.isEnabled = false
+        GrantLogger.logHandler = null
+
+        GrantLogger.d("TestTag", "debug line")
+        GrantLogger.i("TestTag", "info line")
+
+        // Reaching here without a handler installed means nothing was routed anywhere; the
+        // console branch is guarded by isEnabled, which is false.
+        assertFalse(GrantLogger.isEnabled, "isEnabled must still be false")
+        assertNull(GrantLogger.logHandler, "no handler must have been installed")
+    }
+
+    @Test
+    fun `installing a handler is itself an opt-in even with isEnabled false`() {
+        // Pins a subtlety that is easy to get backwards: `isEnabled` gates the built-in
+        // console output, NOT the custom sink. An app that installs a handler receives log
+        // messages whether or not it also sets isEnabled — providing somewhere for logs to go
+        // is the opt-in.
+        //
+        // This is deliberate and safe (the app asked for the sink), but it means
+        // `isEnabled = false` is not a way to silence a handler you have already installed.
+        // To go silent, clear the handler.
+        val received = mutableListOf<String>()
+        GrantLogger.isEnabled = false
+        GrantLogger.logHandler = { _, _, message -> received.add(message) }
+
+        GrantLogger.i("TestTag", "info line")
+
+        assertTrue(
+            received.any { it.contains("info line") },
+            "A host-installed handler receives messages regardless of isEnabled; got $received",
+        )
+    }
+
+    @Test
+    fun `clearing the handler restores silence`() {
+        val received = mutableListOf<String>()
+        GrantLogger.isEnabled = false
+        GrantLogger.logHandler = { _, _, message -> received.add(message) }
+        GrantLogger.logHandler = null
+
+        GrantLogger.i("TestTag", "info line")
+
+        assertTrue(
+            received.isEmpty(),
+            "Removing the handler must stop delivery; got $received",
+        )
+    }
+
+    @Test
+    fun `enabled logger routes to the host handler`() {
+        // The other half of the contract: when the app does opt in, it gets everything, so
+        // it can apply its own redaction or routing policy.
+        val received = mutableListOf<String>()
+        GrantLogger.isEnabled = true
+        GrantLogger.logHandler = { _, _, message -> received.add(message) }
+
+        GrantLogger.i("TestTag", "info line")
+
+        assertTrue(
+            received.any { it.contains("info line") },
+            "An enabled logger must route messages to the host-provided handler, got $received",
+        )
+    }
+}

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantFactory.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/GrantFactory.ios.kt
@@ -7,7 +7,7 @@ import dev.brewkits.grant.impl.PlatformGrantDelegate
  *
  * Accepts GrantStore for state management (in-memory only on iOS).
  */
-actual fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate {
+public actual fun createPlatformDelegate(context: Any?, store: GrantStore?): PlatformGrantDelegate {
     // iOS doesn't use context, only store. Defaults to in-memory; there is no
     // process-death restart-history concern on iOS the way there is on Android.
     return PlatformGrantDelegate(store ?: InMemoryGrantStore())

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/ServiceFactory.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/ServiceFactory.ios.kt
@@ -3,8 +3,8 @@ package dev.brewkits.grant
 import dev.brewkits.grant.impl.MyServiceManager
 import dev.brewkits.grant.impl.PlatformServiceDelegate
 
-actual object ServiceFactory {
-    actual fun createServiceManager(): ServiceManager {
+public actual object ServiceFactory {
+    public actual fun createServiceManager(): ServiceManager {
         return MyServiceManager(
             platformDelegate = PlatformServiceDelegate()
         )

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/IosPermissionHandlerRegistry.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/IosPermissionHandlerRegistry.kt
@@ -10,7 +10,7 @@ package dev.brewkits.grant.handlers
  * If you need to request a permission not covered by [dev.brewkits.grant.AppGrant], 
  * you can implement [PermissionHandler] and register it here.
  */
-object IosPermissionHandlerRegistry {
+public object IosPermissionHandlerRegistry {
     private val handlers = mutableMapOf<String, PermissionHandler>()
 
     /**
@@ -19,7 +19,7 @@ object IosPermissionHandlerRegistry {
      * @param identifier The identifier of the RawPermission.
      * @param handler The custom handler implementation.
      */
-    fun register(identifier: String, handler: PermissionHandler) {
+    public fun register(identifier: String, handler: PermissionHandler) {
         handlers[identifier] = handler
     }
 

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/LocationTemporaryFullAccuracyHandler.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/LocationTemporaryFullAccuracyHandler.kt
@@ -19,7 +19,7 @@ import platform.CoreLocation.CLAccuracyAuthorization
  * IosPermissionHandlerRegistry.register("DeliveryPurpose", LocationTemporaryFullAccuracyHandler("DeliveryPurpose"))
  * ```
  */
-class LocationTemporaryFullAccuracyHandler(
+public class LocationTemporaryFullAccuracyHandler(
     private val purposeKey: String
 ) : PermissionHandler {
 

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/PermissionHandler.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/handlers/PermissionHandler.kt
@@ -12,16 +12,16 @@ import dev.brewkits.grant.GrantStatus
  * See [APPLE_FRAMEWORK_LINKING_ISSUE.md](docs/ios/APPLE_FRAMEWORK_LINKING_ISSUE.md)
  * for the architectural rationale behind this design.
  */
-interface PermissionHandler {
+public interface PermissionHandler {
     /**
      * Returns the current authorization status for this permission.
      * Must be called on the main thread.
      */
-    fun checkStatus(): GrantStatus
+    public fun checkStatus(): GrantStatus
 
     /**
      * Requests authorization from the user.
      * Suspends until the system dialog is dismissed.
      */
-    suspend fun request(): GrantStatus
+    public suspend fun request(): GrantStatus
 }

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
@@ -60,7 +60,7 @@ private const val TAG = "iOSGrantDelegate"
  * - Notification status is checked via its own async path to avoid nested dispatch
  */
 @Suppress("UnusedPrivateProperty")
-actual class PlatformGrantDelegate(
+public actual class PlatformGrantDelegate(
     private val store: GrantStore
 ) {
 
@@ -114,7 +114,7 @@ actual class PlatformGrantDelegate(
     // PUBLIC API
     // ====================================================================
 
-    actual suspend fun checkStatus(grant: GrantPermission): GrantStatus {
+    public actual suspend fun checkStatus(grant: GrantPermission): GrantStatus {
         val identifier = grant.identifier
         return getMutexFor(identifier).withLock {
             mapsMutex.withLock {
@@ -145,10 +145,10 @@ actual class PlatformGrantDelegate(
         }
     }
 
-    actual suspend fun request(grant: GrantPermission): GrantStatus =
+    public actual suspend fun request(grant: GrantPermission): GrantStatus =
         getMutexFor(grant.identifier).withLock { requestInternal(grant) }
 
-    actual suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> {
+    public actual suspend fun request(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> {
         if (grants.isEmpty()) return emptyMap()
         if (grants.size == 1) return mapOf(grants.first() to request(grants.first()))
 
@@ -183,7 +183,7 @@ actual class PlatformGrantDelegate(
      * Opens the app's settings page in iOS Settings.
      * Logs a warning if the Settings URL cannot be resolved (e.g., App Extensions, App Clips).
      */
-    actual fun openSettings() {
+    public actual fun openSettings() {
         val url = NSURL.URLWithString(UIApplicationOpenSettingsURLString)
         if (url == null) {
             GrantLogger.w(TAG, "UIApplicationOpenSettingsURLString could not be resolved. Settings cannot be opened.")
@@ -319,7 +319,7 @@ actual class PlatformGrantDelegate(
      */
     private fun hasInfoPlistKey(key: String): Boolean = hasInfoPlistKey(TAG, key)
 
-    actual fun setLauncher(launcher: GrantLauncher) {}
+    public actual fun setLauncher(launcher: GrantLauncher) {}
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/IosUtils.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/IosUtils.kt
@@ -16,7 +16,7 @@ import platform.Foundation.NSBundle
  * @param key   The Info.plist key to validate (e.g. "NSCameraUsageDescription").
  * @return `true` if the key exists and is non-null, `false` otherwise.
  */
-fun hasInfoPlistKey(tag: String, key: String): Boolean {
+public fun hasInfoPlistKey(tag: String, key: String): Boolean {
     val value = NSBundle.mainBundle.objectForInfoDictionaryKey(key)
     if (value == null) {
         GrantLogger.e(

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/MainThreadUtils.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/MainThreadUtils.kt
@@ -16,7 +16,7 @@ import platform.Foundation.NSThread
 // Using a structured scope would cause the resume to be silently dropped on cancellation,
 // leaving the continuation hanging indefinitely.
 @Suppress("GlobalCoroutineUsage")
-inline fun <T> mainContinuation(
+public inline fun <T> mainContinuation(
     noinline block: (T) -> Unit
 ): (T) -> Unit = { arg ->
     if (NSThread.isMainThread()) {
@@ -32,7 +32,7 @@ inline fun <T> mainContinuation(
  * Wraps a callback with two parameters to ensure it runs on the main thread.
  */
 @Suppress("GlobalCoroutineUsage")
-inline fun <T1, T2> mainContinuation2(
+public inline fun <T1, T2> mainContinuation2(
     noinline block: (T1, T2) -> Unit
 ): (T1, T2) -> Unit = { arg1, arg2 ->
     if (NSThread.isMainThread()) {

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/PlatformLock.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/PlatformLock.ios.kt
@@ -5,11 +5,11 @@ import platform.Foundation.NSRecursiveLock
 internal actual class PlatformLock actual constructor() {
     private val lock = NSRecursiveLock()
 
-    actual fun lock() {
+    public actual fun lock() {
         lock.lock()
     }
 
-    actual fun unlock() {
+    public actual fun unlock() {
         lock.unlock()
     }
 }

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/SimulatorDetector.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/utils/SimulatorDetector.kt
@@ -13,20 +13,20 @@ import platform.UIKit.UIDevice
  * For these permissions, we return mock status on simulator
  * to allow testing without blocking the entire flow.
  */
-object SimulatorDetector {
+public object SimulatorDetector {
 
     /**
      * Set this to false to disable mocking on Simulator.
      * Useful for testing DENIED logic on Simulator.
      */
-    var mockSimulatorGranted: Boolean = true
+    public var mockSimulatorGranted: Boolean = true
 
     /**
      * Check if running on iOS Simulator.
      *
      * Returns true if on simulator, false if on real device.
      */
-    val isSimulator: Boolean by lazy {
+    public val isSimulator: Boolean by lazy {
         // Check device model - simulator always contains "Simulator"
         val model = UIDevice.currentDevice.model
         model.contains("Simulator", ignoreCase = true) ||
@@ -48,6 +48,6 @@ object SimulatorDetector {
     /**
      * Get simulator type name for logging.
      */
-    val simulatorType: String
+    public val simulatorType: String
         get() = if (isSimulator) "iOS Simulator" else "Real Device"
 }

--- a/grant-location-always/build.gradle.kts
+++ b/grant-location-always/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -112,4 +118,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-location-always/src/androidMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
+++ b/grant-location-always/src/androidMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.location
 /**
  * Entry point for initializing the Grant LocationAlways module.
  */
-actual object GrantLocationAlways {
+public actual object GrantLocationAlways {
     /**
      * No-op on Android, as Android handles permissions via Manifest and Intents.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         // No-op
     }
 }

--- a/grant-location-always/src/commonMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
+++ b/grant-location-always/src/commonMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.location
 /**
  * Entry point for initializing the Grant LocationAlways module.
  */
-expect object GrantLocationAlways {
+public expect object GrantLocationAlways {
     /**
      * Initializes the LocationAlways permission handler.
      * Must be called before requesting LocationAlways permissions.
      * It is safe to call this multiple times.
      */
-    fun initialize()
+    public fun initialize()
 }

--- a/grant-location-always/src/iosMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
+++ b/grant-location-always/src/iosMain/kotlin/dev/brewkits/grant/location/GrantLocationAlways.kt
@@ -8,14 +8,14 @@ import dev.brewkits.grant.delegates.LocationAlwaysManagerDelegate
 /**
  * Entry point for initializing the Grant LocationAlways module.
  */
-actual object GrantLocationAlways {
+public actual object GrantLocationAlways {
     private var isInitialized = false
     private val delegate by lazy { LocationAlwaysManagerDelegate() }
 
     /**
      * Registers the LocationAlways permission handler for iOS.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         if (isInitialized) return
         isInitialized = true
         IosPermissionHandlerRegistry.register(AppGrant.LOCATION_ALWAYS.identifier, LocationAlwaysPermissionHandler(delegate))

--- a/grant-motion/build.gradle.kts
+++ b/grant-motion/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kover)
     id("maven-publish")
     alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
 }
 
 group = "dev.brewkits"
@@ -25,6 +26,11 @@ kotlin {
     }
 
     jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
 
     // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
     // Dumps live in api/ and are verified by CI. See grant-core for rationale.
@@ -112,4 +118,16 @@ publishing {
             }
         }
     }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
 }

--- a/grant-motion/src/androidMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
+++ b/grant-motion/src/androidMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.motion
 /**
  * Entry point for initializing the Grant Motion module.
  */
-actual object GrantMotion {
+public actual object GrantMotion {
     /**
      * No-op on Android, as Android handles permissions via Manifest and Intents.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         // No-op
     }
 }

--- a/grant-motion/src/commonMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
+++ b/grant-motion/src/commonMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
@@ -3,11 +3,11 @@ package dev.brewkits.grant.motion
 /**
  * Entry point for initializing the Grant Motion module.
  */
-expect object GrantMotion {
+public expect object GrantMotion {
     /**
      * Initializes the Motion permission handler.
      * Must be called before requesting Motion permissions.
      * It is safe to call this multiple times.
      */
-    fun initialize()
+    public fun initialize()
 }

--- a/grant-motion/src/iosMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
+++ b/grant-motion/src/iosMain/kotlin/dev/brewkits/grant/motion/GrantMotion.kt
@@ -7,13 +7,13 @@ import dev.brewkits.grant.handlers.MotionPermissionHandler
 /**
  * Entry point for initializing the Grant Motion module.
  */
-actual object GrantMotion {
+public actual object GrantMotion {
     private var isInitialized = false
 
     /**
      * Registers the Motion permission handler for iOS.
      */
-    actual fun initialize() {
+    public actual fun initialize() {
         if (isInitialized) return
         isInitialized = true
         IosPermissionHandlerRegistry.register(AppGrant.MOTION.identifier, MotionPermissionHandler())


### PR DESCRIPTION
Builds on #68 (must land first — this branch includes its commit).

Two production-hardening tiers landed together on one branch. **Deviates from the original plan of separate PRs per tier**: every published module's `build.gradle.kts` is touched by both `explicitApi()` and the `cyclonedx` plugin, so clean file-level separation wasn't practical without hunk surgery. Both tiers are independently verified in the same green build.

## R8 validation

`demo`'s release build now has `isMinifyEnabled = true` with `-allowaccessmodification`. `grant-core` had **never** been built under R8 before this, despite nearly every production consumer using it.

`grant-core` ships no consumer ProGuard rules, on the basis that `GrantRequestActivity` and `GrantInitializer` are declared in the library manifest and R8 keeps them automatically. Verified against the release mapping and DEX rather than assumed — both classes keep their names; `AppGrant`/`GrantHandler`/`GrantStatus` are renamed but present.

The check that actually mattered: `SharedPreferencesGrantStore` persists request history keyed on `AppGrant.name`, so if R8 rewrote enum constant name strings, the history would silently break across builds. Checked directly against the release **DEX**, not inferred from the mapping file — every constant checked (`CAMERA`, `GALLERY_ADD_ONLY`, `LOCAL_NETWORK`, ...) survives intact.

`demo/proguard-rules.pro` is deliberately free of Grant-specific keeps — a speculative keep file would disable optimisation for every consumer and hide exactly the breakage this build exists to detect. `ci.yml` now runs `:demo:assembleRelease` so this stays checked continuously.

## `explicitApi()` on all eight modules

~340 declarations gained explicit visibility, plus explicit return types where inference alone doesn't satisfy explicit API mode (`GrantEventListener`'s six no-op defaults, a `when`-expression extension property, an `openSettings()` override, a mutable property, the Koin module `val`s).

**The ABI dumps did not move by one line.** That's the proof the churn was mechanical and no public surface shifted — exactly why the ABI gate from #66 was worth landing before this: 340+ visibility changes would otherwise have needed manual re-verification against intent instead of an automated diff.

## `GrantLogger` privacy contract, pinned — and one of my own test mistakes caught along the way

`isEnabled` defaults to `false` with no handler installed. Pinned with `LoggerPrivacyDefaultTest`.

> [!NOTE]
> The first version of that test asserted something the library doesn't actually promise: that installing a handler while `isEnabled` is `false` stays silent. It doesn't — **installing a handler is itself the opt-in**, independent of `isEnabled`, which gates only the built-in console branch. The test was wrong, not the library. Corrected to match the real contract, and documented on both properties so the same mistake isn't easy to make from the API alone.

## SBOM

CycloneDX applied **per published module**, not at the root — a root-level BOM task also walks `:demo`, whose Kotlin/Native and Compose configurations the 1.4.0 plugin can't resolve (`skipProjects` isn't available at that version). Restricted to `releaseRuntimeClasspath`. `./gradlew cyclonedxBom` → `<module>/build/reports/bom.json`. Verified non-trivial output: `grant-core`'s BOM lists 59 components.

## Support policy

New `SUPPORT.md`: semantic versioning tied to the ABI gate, a six-month security tail for the previous major, platform support table, and an explicit **"what Grant will not do"** section (no injected permissions, no data collection, no logging without opt-in, no review-circumvention). `minSdk` is called out as raised only in a major release — it breaks apps supporting older devices, so it's a breaking change, not housekeeping.

README gained a size/supply-chain section with per-module AAR sizes and a more honest number: Grant contributes **83 classes out of 2,686** in the R8-minified demo APK. Also documents the decision **not** to ship a Baseline Profile — Grant's entire startup contribution is one `ContentProvider.onCreate()` registering a lifecycle callback, and the permission request path is user-triggered and gated behind a system dialog, where JIT vs AOT isn't a measurable difference.

## Verification

```
./gradlew build allTests checkKotlinAbi :demo:assembleRelease
-> BUILD SUCCESSFUL, 1461 tests, 0 failures, api/ dumps unchanged
```