### PR TITLE
fix: owned launch guard, main-thread I/O, cancellation, and lock contention on Android

### DIFF
--- a/docs/architecture/grant-store.md
+++ b/docs/architecture/grant-store.md
@@ -53,6 +53,33 @@ val grantManager = GrantFactory.create(applicationContext, store = InMemoryGrant
 | "has been requested" flags (`isRequestedBefore`, raw permissions) | SharedPreferences | ✅ Yes |
 | Per-session status cache (`getStatus`/`setStatus`) | In-memory map | ❌ No — OS is the source of truth |
 
+### Startup cost, and `warmUp()`
+
+Reading this store the first time does two blocking things: a SharedPreferences disk read (XML
+parse) and a `PackageManager.getPackageInfo()` call — a binder round trip to `system_server`,
+used for the install-identity stamp described below.
+
+Both are deferred until the store is **first read**, not done when it is constructed, so
+`GrantFactory.create(applicationContext)` and the Koin `single { }` stay cheap. Deferring does
+not make the work free, though — it just moves it to whichever thread reads first.
+
+Apps with a tight frame budget (camera preview, games, anything targeting 120 fps, where a
+frame is ~8 ms) should pay that cost up front, off the main thread:
+
+```kotlin
+class MyApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        val store = SharedPreferencesGrantStore(this)
+        applicationScope.launch(Dispatchers.IO) { store.warmUp() }   // blocking; keep it off main
+        grantManager = GrantFactory.create(this, store = store)
+    }
+}
+```
+
+`warmUp()` is optional — skipping it is correct, and most apps will never notice. It exists so
+that the one unavoidable disk-and-binder cost does not land on a frame that cannot afford it.
+
 ### Why this is safe (no status desync)
 
 The classic argument against persisting permission state is *desync*: if you cache `CAMERA = DENIED` and the user later enables it in Settings, your cache is wrong. `SharedPreferencesGrantStore` sidesteps this entirely because it **never persists status** — only the immutable fact "this permission was requested at least once", which can never become stale. The live status is always re-read from the OS.

--- a/grant-core/api/android/grant-core.api
+++ b/grant-core/api/android/grant-core.api
@@ -432,6 +432,7 @@ public final class dev/brewkits/grant/SharedPreferencesGrantStore : dev/brewkits
 	public fun markRawPermissionRequested (Ljava/lang/String;)V
 	public fun setRequested (Ldev/brewkits/grant/AppGrant;)V
 	public fun setStatus (Ldev/brewkits/grant/AppGrant;Ldev/brewkits/grant/GrantStatus;)V
+	public final fun warmUp ()V
 }
 
 public final class dev/brewkits/grant/impl/AndroidGrantLauncher : dev/brewkits/grant/GrantLauncher {

--- a/grant-core/src/androidMain/AndroidManifest.xml
+++ b/grant-core/src/androidMain/AndroidManifest.xml
@@ -52,6 +52,22 @@
           than crashes.
     -->
 
+    <!--
+        On android:stateNotNeeded="true" alongside GrantRequestViewModel's SavedStateHandle,
+        which looks contradictory but is not:
+
+        - Across a CONFIGURATION CHANGE the ViewModel is retained in memory, so requestId and
+          alreadyLaunched survive without onSaveInstanceState being involved at all. This is
+          the case that actually matters (rotating the device while the system dialog is up).
+        - Across PROCESS DEATH nothing can be restored anyway: the pending CompletableDeferred
+          lives in a static map that dies with the process, and the coroutine awaiting it is
+          gone too. onCreate() therefore falls back to the intent extra, which does survive,
+          purely so the restored Activity can finish cleanly instead of hanging.
+
+        stateNotNeeded="true" tells the OS not to spend effort preserving state for a
+        transparent, short-lived dialog host whose state cannot be meaningfully restored. It
+        does not weaken the configuration-change path.
+    -->
     <application>
         <activity
             android:name="dev.brewkits.grant.impl.GrantRequestActivity"

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/SharedPreferencesGrantStore.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/SharedPreferencesGrantStore.kt
@@ -1,6 +1,7 @@
 package dev.brewkits.grant
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import dev.brewkits.grant.utils.GrantLogger
 import dev.brewkits.grant.utils.withLock
@@ -49,11 +50,47 @@ public class SharedPreferencesGrantStore(context: Context) : GrantStore {
 
     private val appContext = context.applicationContext
 
-    private val prefs = appContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    /**
+     * Deliberately `by lazy`, and the install check runs inside it.
+     *
+     * Constructing this store used to do two blocking things eagerly:
+     * `getSharedPreferences()` (a disk read and XML parse) and, via
+     * [discardHistoryFromOtherInstalls], `PackageManager.getPackageInfo()` — a binder round
+     * trip to `system_server`. Both ran on whichever thread built the object, which in
+     * practice is the main thread: `GrantFactory.create(applicationContext)` is normally
+     * called from `Application.onCreate()` or a ViewModel, and the Koin `single { }` is
+     * resolved by the first screen that asks for it. At a 120 fps frame budget of ~8 ms, a
+     * binder call alone can blow the frame, and `StrictMode.detectDiskReads()` flags it.
+     *
+     * Deferring to first *use* keeps object construction free. It does not make the work
+     * disappear, so [warmUp] exists to pay it on a background thread before the UI
+     * needs an answer; apps with a strict frame budget should call it.
+     */
+    private val prefs: SharedPreferences by lazy {
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { discardHistoryFromOtherInstalls(it) }
+    }
 
-    init {
-        discardHistoryFromOtherInstalls()
+    /**
+     * Forces this store's disk read and `PackageManager` lookup to happen now, on the calling
+     * thread, so the first real read does not pay for them.
+     *
+     * **Blocking — call it from a background thread**, e.g. from `Application.onCreate()`:
+     * ```kotlin
+     * applicationScope.launch(Dispatchers.IO) { store.warmUp() }
+     * ```
+     *
+     * Deliberately blocking and dispatcher-free rather than taking a `CoroutineScope`: that
+     * would put `kotlinx.coroutines` types into this module's public ABI, and coroutines is an
+     * `implementation` dependency here. The caller already knows which scope and dispatcher it
+     * wants; this only needs to be *called* from the right one.
+     *
+     * Optional. Skipping it is correct — the cost simply lands on whichever thread first
+     * touches the store, which for an app with a tight frame budget (camera preview, games)
+     * may be a frame that cannot afford it.
+     */
+    public fun warmUp() {
+        prefs
     }
 
     /**
@@ -73,7 +110,7 @@ public class SharedPreferencesGrantStore(context: Context) : GrantStore {
      * [android.content.SharedPreferences.contains] rather than a default value, because 0
      * is a legitimate `firstInstallTime` in some environments (Robolectric reports it).
      */
-    private fun discardHistoryFromOtherInstalls() {
+    private fun discardHistoryFromOtherInstalls(prefs: SharedPreferences) {
         val currentIdentity = currentInstallIdentity() ?: return
 
         if (prefs.contains(KEY_INSTALL_IDENTITY) &&
@@ -112,6 +149,14 @@ public class SharedPreferencesGrantStore(context: Context) : GrantStore {
 
     // Status is session state only — the OS is the source of truth for the live status,
     // so it is intentionally not persisted alongside the request history.
+    //
+    // NOT a performance cache, and not a duplicate of PlatformGrantDelegate's TTL-based
+    // statusCacheMap despite the similar name. This one has exactly one reader: the branch in
+    // checkStatus() that runs when there is no Activity available to consult
+    // shouldShowRequestPermissionRationale(). There, "the last status we actually observed" is
+    // the only signal left for telling DENIED from DENIED_ALWAYS. It has no TTL on purpose —
+    // a stale answer beats no answer in that branch, and the OS is re-consulted as soon as an
+    // Activity exists again.
     private val statusCache = mutableMapOf<AppGrant, GrantStatus>()
     private val lock = dev.brewkits.grant.utils.PlatformLock()
 

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/GrantRequestActivity.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/GrantRequestActivity.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.ViewModel
 import dev.brewkits.grant.utils.GrantLogger
 import kotlinx.coroutines.CompletableDeferred
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import java.util.UUID
 
 public class GrantRequestViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
@@ -48,13 +48,9 @@ public class GrantRequestActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
-        // Ensure the static guard is set even if recreated by OS after process death
-        isActivityActive.set(true)
-        lastActivityLaunchTime = System.currentTimeMillis()
 
         try {
-            val requestId = viewModel.requestId 
+            val requestId = viewModel.requestId
                 ?: intent.getStringExtra(EXTRA_REQUEST_ID)
                 ?: ""
 
@@ -63,8 +59,15 @@ public class GrantRequestActivity : ComponentActivity() {
                 finishAndCleanup()
                 return
             }
-            
+
             viewModel.requestId = requestId
+
+            // Claim the guard for THIS request. Normally requestGrants() already set it to
+            // this same id, and the CAS is a no-op. After process death the static guard is
+            // gone, so this re-establishes ownership for the restored Activity — which is why
+            // it is done here, with the id in hand, rather than unconditionally above.
+            guardOwner.compareAndSet(null, requestId)
+            lastActivityLaunchTime = System.currentTimeMillis()
 
             currentGrants = intent.getStringArrayExtra(EXTRA_GRANTS) ?: run {
                 setResult(requestId, GrantResult.ERROR)
@@ -95,11 +98,12 @@ public class GrantRequestActivity : ComponentActivity() {
                         val rid = viewModel.requestId ?: ""
                         val deferred = pendingResults[rid]
                         if (deferred?.isActive == true) {
+                            // Complete so a caller awaiting this never hangs, but leave the
+                            // entry: the caller's own finally-block calls cleanup(rid).
                             setResult(rid, GrantResult.ERROR)
-                            pendingResults.remove(rid)
-                            pendingTimestamps.remove(rid)
                         }
-                        isActivityActive.set(false)
+                        // Release only if this Activity's request owns the guard.
+                        guardOwner.compareAndSet(rid, null)
                     }
                     requestMultipleGrantsLauncher?.unregister()
                     requestMultipleGrantsLauncher = null
@@ -134,7 +138,9 @@ public class GrantRequestActivity : ComponentActivity() {
     }
 
     private fun finishAndCleanup() {
-        isActivityActive.set(false)
+        // Release only this request's own claim; a blind clear here would free a guard held
+        // by a different, still-live request (see the KDoc on guardOwner).
+        viewModel.requestId?.let { guardOwner.compareAndSet(it, null) }
         finish()
         overridePendingTransition(0, 0)
     }
@@ -154,16 +160,43 @@ public class GrantRequestActivity : ComponentActivity() {
         // Increase cleanup threshold to handle slow devices or long rationale reading
         private const val ORPHAN_CLEANUP_THRESHOLD_MS = 300_000L // 5 minutes
 
-        private val isActivityActive = AtomicBoolean(false)
+        /** How long a guard may be held before a new request may take it as stale. */
+        private const val GUARD_STALE_AFTER_MS = 60_000L
+
+        /**
+         * The request that currently owns the single-Activity guard, or `null` when free.
+         *
+         * An `AtomicBoolean` was not enough: [cleanup] is called by every request, including
+         * one that *lost* the race, and an unowned flag let that loser clear the winner's
+         * guard while the winner's system dialog was still on screen. A second Activity could
+         * then launch over the first, and — worse — the loser's own entry was removed before
+         * its caller could await it, so `request()` returned without ever showing a dialog.
+         * Storing *who* holds the guard makes release a compare-and-set instead of a blind
+         * write, so only the owner can free it. Regression test:
+         * `GrantRequestActivityGuardTest`.
+         */
+        private val guardOwner = AtomicReference<String?>(null)
+
+        /**
+         * `@Volatile`: written from [requestGrants] (any thread) and from `onCreate` (main),
+         * read from [requestGrants]. Without it a stale read could satisfy the 60-second
+         * staleness check below and steal the guard from a legitimately running Activity.
+         */
+        @Volatile
         private var lastActivityLaunchTime = 0L
 
         /**
          * Check if any GrantRequestActivity is currently active.
          */
-        public fun isAnyActivityActive(): Boolean = isActivityActive.get()
+        public fun isAnyActivityActive(): Boolean = guardOwner.get() != null
 
         /**
          * Launch this Activity to request one or more grants.
+         *
+         * On success the returned id has a pending result the caller must await and then
+         * [cleanup]. When the guard is already held, the returned id's result is completed
+         * with [GrantResult.ERROR] but **left in the map**, so the caller still awaits a
+         * determinate answer rather than finding nothing and returning silently.
          */
         public fun requestGrants(context: Context, androidGrants: List<String>): String {
             val requestId = UUID.randomUUID().toString()
@@ -176,17 +209,19 @@ public class GrantRequestActivity : ComponentActivity() {
 
             cleanupOrphanedEntries()
 
-            // Apply timeout reset before CAS to handle stuck guard state
-            if (isActivityActive.get() && (now - lastActivityLaunchTime > 60_000L)) {
-                GrantLogger.w(TAG, "Activity guard reset after 60s timeout.")
-                isActivityActive.set(false)
+            // Free a guard whose owner is demonstrably stale. compareAndSet against the
+            // owner we observed, so an owner that changed in the meantime is never clobbered.
+            val staleOwner = guardOwner.get()
+            if (staleOwner != null && (now - lastActivityLaunchTime > GUARD_STALE_AFTER_MS)) {
+                GrantLogger.w(TAG, "Activity guard reset after ${GUARD_STALE_AFTER_MS}ms timeout.")
+                guardOwner.compareAndSet(staleOwner, null)
             }
 
-            // Atomic check-and-set: only one concurrent caller proceeds
-            if (!isActivityActive.compareAndSet(false, true)) {
+            // Atomic claim: only one concurrent caller becomes the owner.
+            if (!guardOwner.compareAndSet(null, requestId)) {
                 GrantLogger.w(TAG, "Activity Launch Guard: Another GrantRequestActivity is already active. Yielding.")
+                // Complete but do NOT remove: the caller awaits this and cleans it up itself.
                 pendingResults[requestId]?.complete(GrantResult.ERROR)
-                cleanup(requestId)
                 return requestId
             }
 
@@ -204,9 +239,10 @@ public class GrantRequestActivity : ComponentActivity() {
                 appContext.startActivity(intent)
             } catch (e: Exception) {
                 GrantLogger.e(TAG, "Failed to start GrantRequestActivity", e)
-                isActivityActive.set(false)
+                // Complete but leave the entry for the caller to await and clean up; only the
+                // guard is released here, and only because this request owns it.
+                guardOwner.compareAndSet(requestId, null)
                 pendingResults[requestId]?.complete(GrantResult.ERROR)
-                cleanup(requestId)
             }
 
             return requestId
@@ -237,10 +273,27 @@ public class GrantRequestActivity : ComponentActivity() {
             return pendingResults[requestId]
         }
 
+        /**
+         * Drops this request's pending entry and releases the guard **only if this request
+         * holds it**. The compare-and-set is the fix for the defect described on [guardOwner]:
+         * a blind `set(false)` here let a request that never owned the guard free it out from
+         * under the one that did.
+         */
         internal fun cleanup(requestId: String) {
             pendingResults.remove(requestId)
             pendingTimestamps.remove(requestId)
-            isActivityActive.set(false)
+            guardOwner.compareAndSet(requestId, null)
+        }
+
+        /**
+         * Test-only escape hatch: the guard is process-wide static state, so a test that ends
+         * while holding it would poison every test after it. Not part of the production flow —
+         * production code releases the guard through [cleanup], which only the owner can do.
+         */
+        internal fun forceReleaseGuardForTest() {
+            guardOwner.set(null)
+            pendingResults.clear()
+            pendingTimestamps.clear()
         }
     }
 

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeout
 import java.util.Collections
 import java.util.WeakHashMap
@@ -39,25 +41,64 @@ public actual class PlatformGrantDelegate(
         trackForegroundActivity(context)
     }
 
+    @Volatile
     private var launcher: GrantLauncher? = null
     public actual fun setLauncher(launcher: GrantLauncher) { this.launcher = launcher }
+
     /**
-     * Protects all map structures (mutexMapInternal, statusCacheMap).
+     * One mutex per permission identifier, so requests for different permissions never
+     * serialise against each other.
+     *
+     * `computeIfAbsent` rather than a surrounding `Mutex`: the invariant that matters is
+     * "exactly one [ReentrantMutex] per identifier", and that is precisely what
+     * [ConcurrentHashMap.computeIfAbsent] guarantees atomically. The previous code wrapped
+     * this — and every [statusCacheMap] read and write — in a single global `mapsMutex`,
+     * which serialised *all* permission checks against one another on the hot path while
+     * adding nothing the concurrent map did not already provide.
      */
-    private val mapsMutex = Mutex()
     private val mutexMapInternal = ConcurrentHashMap<String, ReentrantMutex>()
 
-    private suspend fun getMutexFor(identifier: String): ReentrantMutex {
-        return mapsMutex.withLock {
-            mutexMapInternal.getOrPut(identifier) { ReentrantMutex() }
-        }
-    }
+    private fun getMutexFor(identifier: String): ReentrantMutex =
+        mutexMapInternal.computeIfAbsent(identifier) { ReentrantMutex() }
 
     // Notification status cache with timestamp (Android 12 and below)
+    @Volatile
     private var notificationStatusCache: Pair<GrantStatus, Long>? = null
 
-    // Short-lived status cache for all grants to prevent redundant OS calls
-    private val statusCacheMap = ConcurrentHashMap<String, Pair<GrantStatus, Long>>()
+    /**
+     * Short-lived status cache, bounded by [MAX_TRACKED_IDENTIFIERS].
+     *
+     * The bound exists because [RawPermission.identifier] is an arbitrary app-supplied string:
+     * an app that mints identifiers dynamically would otherwise grow this map — and
+     * [mutexMapInternal] with it — without limit for the lifetime of the process. Access-order
+     * `LinkedHashMap` + `removeEldestEntry` evicts the least recently used identifier instead.
+     * Eviction is safe here because an entry is only a cached *value*; losing it costs one
+     * extra OS call, never correctness. [mutexMapInternal] is deliberately NOT evicted the same
+     * way — dropping a mutex another coroutine currently holds would break mutual exclusion —
+     * see [pruneMutexesIfNeeded].
+     */
+    private val statusCacheMap: MutableMap<String, Pair<GrantStatus, Long>> =
+        Collections.synchronizedMap(
+            object : LinkedHashMap<String, Pair<GrantStatus, Long>>(16, 0.75f, true) {
+                override fun removeEldestEntry(
+                    eldest: MutableMap.MutableEntry<String, Pair<GrantStatus, Long>>,
+                ): Boolean = size > MAX_TRACKED_IDENTIFIERS
+            }
+        )
+
+    /**
+     * Drops mutexes for identifiers no longer being tracked, but only ones that are currently
+     * unlocked — a held mutex must never be replaced, or two coroutines would each get their
+     * own instance and mutual exclusion would silently disappear.
+     *
+     * Called opportunistically after a status write rather than on a timer: the map only grows
+     * when new identifiers appear, so that is the only moment pruning can be needed.
+     */
+    private fun pruneMutexesIfNeeded() {
+        if (mutexMapInternal.size <= MAX_TRACKED_IDENTIFIERS) return
+        val live = statusCacheMap.keys.toSet()
+        mutexMapInternal.entries.removeIf { (id, mutex) -> id !in live && !mutex.isLocked }
+    }
 
     public companion object {
         private const val TAG = "AndroidGrantDelegate"
@@ -75,6 +116,13 @@ public actual class PlatformGrantDelegate(
 
         private const val NOTIFICATION_CACHE_TTL_MS = 200L
         private const val SYSTEM_DIALOG_TIMEOUT_MS = 300_000L // 5 minutes (matches activity cleanup)
+
+        /**
+         * Upper bound on tracked permission identifiers. Comfortably above the 20 [AppGrant]
+         * values plus any realistic set of app-defined [RawPermission]s, so a normal app never
+         * evicts; it exists to cap an app that mints identifiers dynamically.
+         */
+        private const val MAX_TRACKED_IDENTIFIERS = 64
 
         // Tracks which Application instances already have the lifecycle callback below
         // registered, so creating multiple PlatformGrantDelegate instances (e.g. in tests,
@@ -131,121 +179,143 @@ public actual class PlatformGrantDelegate(
 
     public actual suspend fun checkStatus(grant: GrantPermission): GrantStatus {
         val identifier = grant.identifier
-        
+
         return getMutexFor(identifier).withLock {
-            // Protect statusCacheMap reads through mapsMutex
-            val cached = mapsMutex.withLock {
-                statusCacheMap[identifier]?.let { (cachedStatus, timestamp) ->
-                    if (SystemClock.elapsedRealtime() - timestamp < STATUS_CACHE_TTL_MS) {
-                        cachedStatus
-                    } else null
-                }
+            val cached = statusCacheMap[identifier]?.let { (cachedStatus, timestamp) ->
+                if (SystemClock.elapsedRealtime() - timestamp < STATUS_CACHE_TTL_MS) cachedStatus else null
             }
             if (cached != null) return@withLock cached
 
-            val status = if (grant is RawPermission) {
-                val androidPermissions = grant.androidPermissions
-                val allGranted = androidPermissions.all { 
-                    ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED 
-                }
-                if (allGranted) GrantStatus.GRANTED
-                else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) == PackageManager.PERMISSION_GRANTED) {
-                    GrantStatus.PARTIAL_GRANTED
-                } else {
-                    // shouldShowRequestPermissionRationale() is OS-persisted and survives process
-                    // death, unlike store.isRawPermissionRequested(). Check it first so a soft
-                    // denial is still detected after an app restart (Issue #55).
-                    val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
-                    val anyCanShowRationale = activeActivity != null &&
-                        androidPermissions.any { activeActivity.shouldShowRequestPermissionRationale(it) }
-                    when {
-                        anyCanShowRationale -> GrantStatus.DENIED
-                        store.isRawPermissionRequested(grant.identifier) -> {
-                            // Fallback to DENIED to allow rationale display if activity context is missing.
-                            if (activeActivity == null) GrantStatus.DENIED else GrantStatus.DENIED_ALWAYS
-                        }
-                        else -> GrantStatus.NOT_DETERMINED
-                    }
-                }
-            } else {
-                val appGrant = grant as AppGrant
-                val overrideStatus = getGrantStatusOverride(appGrant)
-                if (overrideStatus != null) {
-                    overrideStatus
-                } else if (appGrant == AppGrant.LOCATION_ALWAYS && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val hasForeground = listOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION).all {
-                        ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-                    }
-                    val hasBackground = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED
-
-                    // shouldShowRequestPermissionRationale() is OS-persisted and survives process
-                    // death, unlike store.isRequestedBefore(). Check it first so a soft denial is
-                    // still detected after an app restart (Issue #55).
-                    val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
-                    val canShowRationale = activeActivity?.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_BACKGROUND_LOCATION) == true
-
-                    when {
-                        hasBackground -> GrantStatus.GRANTED
-                        hasForeground -> GrantStatus.PARTIAL_GRANTED
-                        canShowRationale -> GrantStatus.DENIED
-                        store.isRequestedBefore(appGrant) -> if (activeActivity == null) GrantStatus.DENIED else GrantStatus.DENIED_ALWAYS
-                        else -> GrantStatus.NOT_DETERMINED
-                    }
-                } else {
-                    val androidGrants = appGrant.toAndroidGrants()
-                    if (androidGrants.isEmpty()) GrantStatus.GRANTED
-                    else {
-                        // Full access is judged on the REQUIRED permissions only — see
-                        // toRequiredAndroidGrants(). Counting READ_MEDIA_VISUAL_USER_SELECTED here
-                        // misclassified a fully-granted gallery (IMAGES + VIDEO granted, USER_SELECTED
-                        // not) as denied → DENIED_ALWAYS (Issue: Lam gallery P0, 2026-07-09).
-                        val requiredGrants = appGrant.toRequiredAndroidGrants()
-                        val allGranted = requiredGrants.isNotEmpty() && requiredGrants.all {
-                            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-                        }
-                        if (allGranted) GrantStatus.GRANTED
-                        else if ((appGrant == AppGrant.GALLERY || appGrant == AppGrant.GALLERY_IMAGES_ONLY || appGrant == AppGrant.GALLERY_VIDEO_ONLY) && isPartialGalleryAccessGranted()) {
-                            GrantStatus.PARTIAL_GRANTED
-                        } else if (appGrant == AppGrant.LOCATION && isApproximateLocationGranted()) {
-                            // 2.3.0: the user picked "Approximate" in the OS dialog — COARSE is
-                            // granted, FINE is not. The app HAS usable (coarse) location, but the
-                            // all-granted check above fails and the request-history fallback used
-                            // to escalate this to DENIED_ALWAYS. Same defect class as the gallery
-                            // USER_SELECTED misclassification. Android 17's dialog makes the
-                            // Precise/Approximate choice more prominent, so this state is common.
-                            GrantStatus.PARTIAL_GRANTED
-                        } else {
-                            // shouldShowRequestPermissionRationale() is the OS source of truth for the
-                            // live DENIED vs DENIED_ALWAYS distinction. Consult it FIRST so an in-session
-                            // second denial is seen as permanent immediately, not masked by a stale
-                            // stored DENIED (Issue #55 follow-up). Mirrors the RawPermission/LOCATION_ALWAYS branches.
-                            val activeActivity = PlatformConfig.activity ?: (context as? android.app.Activity)
-                            val anyCanShowRationale = activeActivity != null &&
-                                androidGrants.any { activeActivity.shouldShowRequestPermissionRationale(it) }
-                            when {
-                                anyCanShowRationale -> GrantStatus.DENIED
-                                store.isRequestedBefore(appGrant) ->
-                                    // Requested before and no rationale → permanently denied. With no
-                                    // Activity to confirm, fall back to the last stored status (or DENIED,
-                                    // which keeps the rationale path open).
-                                    if (activeActivity == null) store.getStatus(appGrant) ?: GrantStatus.DENIED
-                                    else GrantStatus.DENIED_ALWAYS
-                                // Never requested → getStatus() is always null here (setStatus only ever
-                                // follows setRequested), so this is simply NOT_DETERMINED.
-                                else -> GrantStatus.NOT_DETERMINED
-                            }
-                        }
-                    }
-                }
+            val status = when {
+                grant is RawPermission -> resolveRawPermission(grant)
+                grant is AppGrant -> resolveAppGrant(grant)
+                // GrantPermission is sealed, so this is unreachable; reporting NOT_DETERMINED
+                // rather than throwing keeps an unknown future subtype from crashing a caller.
+                else -> GrantStatus.NOT_DETERMINED
             }
 
-            // Protect statusCacheMap writes through mapsMutex
-            mapsMutex.withLock {
-                statusCacheMap[identifier] = status to SystemClock.elapsedRealtime()
-            }
+            statusCacheMap[identifier] = status to SystemClock.elapsedRealtime()
+            pruneMutexesIfNeeded()
             status
         }
     }
+
+    /**
+     * The Activity to consult for `shouldShowRequestPermissionRationale()`, or `null` when the
+     * app has none in the foreground.
+     *
+     * [PlatformConfig.activity] is kept current by the lifecycle callback registered in
+     * [trackForegroundActivity]; the cast is the fallback for an app that passed an Activity
+     * as the delegate's own context.
+     */
+    private fun activeActivity(): Activity? =
+        PlatformConfig.activity ?: (context as? Activity)
+
+    /**
+     * Classifies a permission that is not currently granted into DENIED / DENIED_ALWAYS /
+     * NOT_DETERMINED.
+     *
+     * This ordering is the heart of Issue #55 and its follow-up, and was duplicated three
+     * times before being extracted here — once per permission shape, with the copies drifting
+     * apart in exactly the way that made the original bug hard to see.
+     *
+     * `shouldShowRequestPermissionRationale()` is consulted **first** because it is the OS's
+     * own live signal and survives process death, unlike the request history in [store]. A
+     * second in-session denial therefore reads as permanent immediately, instead of being
+     * masked by a stale stored DENIED.
+     *
+     * @param noActivityFallback what to report when the permission was requested before but no
+     *   Activity is available to confirm permanence. Defaults to DENIED, which keeps the
+     *   rationale path open rather than sending the user to Settings on a guess.
+     */
+    private fun classifyDenial(
+        permissions: List<String>,
+        wasRequestedBefore: Boolean,
+        noActivityFallback: () -> GrantStatus = { GrantStatus.DENIED },
+    ): GrantStatus {
+        val activity = activeActivity()
+        val canShowRationale = activity != null &&
+            permissions.any { activity.shouldShowRequestPermissionRationale(it) }
+        return when {
+            canShowRationale -> GrantStatus.DENIED
+            wasRequestedBefore -> if (activity == null) noActivityFallback() else GrantStatus.DENIED_ALWAYS
+            else -> GrantStatus.NOT_DETERMINED
+        }
+    }
+
+    private fun resolveRawPermission(grant: RawPermission): GrantStatus {
+        val permissions = grant.androidPermissions
+        if (permissions.all { isGranted(it) }) return GrantStatus.GRANTED
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            isGranted(READ_MEDIA_VISUAL_USER_SELECTED)
+        ) {
+            return GrantStatus.PARTIAL_GRANTED
+        }
+
+        return classifyDenial(permissions, store.isRawPermissionRequested(grant.identifier))
+    }
+
+    private fun resolveAppGrant(appGrant: AppGrant): GrantStatus {
+        getGrantStatusOverride(appGrant)?.let { return it }
+
+        if (appGrant == AppGrant.LOCATION_ALWAYS && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return resolveLocationAlways(appGrant)
+        }
+
+        val androidGrants = appGrant.toAndroidGrants()
+        // No mapped permission on this API level means nothing to ask for — e.g. GALLERY_ADD_ONLY
+        // needs no permission at all under scoped storage on API 29+.
+        if (androidGrants.isEmpty()) return GrantStatus.GRANTED
+
+        // Full access is judged on the REQUIRED permissions only — see toRequiredAndroidGrants().
+        // Counting READ_MEDIA_VISUAL_USER_SELECTED here misclassified a fully-granted gallery
+        // (IMAGES + VIDEO granted, USER_SELECTED not) as denied -> DENIED_ALWAYS
+        // (Issue: Lam gallery P0, 2026-07-09).
+        val requiredGrants = appGrant.toRequiredAndroidGrants()
+        if (requiredGrants.isNotEmpty() && requiredGrants.all { isGranted(it) }) return GrantStatus.GRANTED
+
+        if (appGrant.isGalleryRead() && isPartialGalleryAccessGranted()) return GrantStatus.PARTIAL_GRANTED
+
+        // 2.3.0: the user picked "Approximate" in the OS dialog — COARSE is granted, FINE is not.
+        // The app HAS usable (coarse) location, but the all-granted check above fails and the
+        // request-history fallback used to escalate this to DENIED_ALWAYS. Same defect class as
+        // the gallery USER_SELECTED misclassification. Android 17's dialog makes the
+        // Precise/Approximate choice more prominent, so this state is common.
+        if (appGrant == AppGrant.LOCATION && isApproximateLocationGranted()) return GrantStatus.PARTIAL_GRANTED
+
+        return classifyDenial(
+            permissions = androidGrants,
+            wasRequestedBefore = store.isRequestedBefore(appGrant),
+            // Requested before and no rationale -> permanently denied. With no Activity to
+            // confirm, fall back to the last status actually observed. (Never requested implies
+            // getStatus() is null, since setStatus only ever follows setRequested.)
+            noActivityFallback = { store.getStatus(appGrant) ?: GrantStatus.DENIED },
+        )
+    }
+
+    private fun resolveLocationAlways(appGrant: AppGrant): GrantStatus {
+        val hasForeground = listOf(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+        ).all { isGranted(it) }
+        val hasBackground = isGranted(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        return when {
+            hasBackground -> GrantStatus.GRANTED
+            hasForeground -> GrantStatus.PARTIAL_GRANTED
+            else -> classifyDenial(
+                permissions = listOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+                wasRequestedBefore = store.isRequestedBefore(appGrant),
+            )
+        }
+    }
+
+    private fun isGranted(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun AppGrant.isGalleryRead(): Boolean =
+        this == AppGrant.GALLERY || this == AppGrant.GALLERY_IMAGES_ONLY || this == AppGrant.GALLERY_VIDEO_ONLY
 
     public actual suspend fun request(grant: GrantPermission): GrantStatus {
         return getMutexFor(grant.identifier).withLock {
@@ -271,7 +341,7 @@ public actual class PlatformGrantDelegate(
     }
 
     private suspend fun requestInternal(grant: GrantPermission): GrantStatus {
-        mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
+        statusCacheMap.remove(grant.identifier)
 
         var currentStatus = checkStatus(grant)
         if (currentStatus == GrantStatus.GRANTED) return currentStatus
@@ -299,8 +369,13 @@ public actual class PlatformGrantDelegate(
             launcher.launch(androidPermissions) { _ -> deferred.complete(Unit) }
             try {
                 withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+            } catch (e: TimeoutCancellationException) {
+                // Before CancellationException: this is our own timeout, an outcome to absorb.
+                GrantLogger.e(TAG, "System dialog timed out", e)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                GrantLogger.e(TAG, "System dialog timeout or error", e)
+                GrantLogger.e(TAG, "System dialog error", e)
             }
         } else {
             // No GrantLauncher registered — fall back to the self-contained transparent
@@ -311,7 +386,7 @@ public actual class PlatformGrantDelegate(
         }
 
         // Invalidate cache immediately after system dialog returns
-        mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
+        statusCacheMap.remove(grant.identifier)
 
         var finalStatus = checkStatus(grant)
 
@@ -338,12 +413,16 @@ public actual class PlatformGrantDelegate(
                 if (bgDeferred != null) {
                     try {
                         withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { bgDeferred.await() }
+                    } catch (e: TimeoutCancellationException) {
+                        GrantLogger.w(TAG, "LOCATION_ALWAYS background step timed out: ${e.message}")
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         GrantLogger.w(TAG, "LOCATION_ALWAYS background step failed: ${e.message}")
                     } finally {
                         GrantRequestActivity.cleanup(bgRequestId)
                     }
-                    mapsMutex.withLock { statusCacheMap.remove(grant.identifier) }
+                    statusCacheMap.remove(grant.identifier)
                     finalStatus = checkStatus(grant)
                 }
             }
@@ -358,9 +437,7 @@ public actual class PlatformGrantDelegate(
     }
 
     private suspend fun requestMultipleInternal(grants: List<GrantPermission>): Map<GrantPermission, GrantStatus> {
-        mapsMutex.withLock {
-            grants.forEach { statusCacheMap.remove(it.identifier) }
-        }
+        grants.forEach { statusCacheMap.remove(it.identifier) }
 
         val allAndroidPermissions = mutableSetOf<String>()
         grants.forEach { grant ->
@@ -387,8 +464,12 @@ public actual class PlatformGrantDelegate(
             launcher.launch(allAndroidPermissions.toList()) { _ -> deferred.complete(true) }
             try {
                 withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+            } catch (e: TimeoutCancellationException) {
+                GrantLogger.e(TAG, "Multi-request timed out", e)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                GrantLogger.e("AndroidGrant", "Multi-request failed", e)
+                GrantLogger.e(TAG, "Multi-request failed", e)
             }
         } else {
             // No GrantLauncher registered — fall back to the self-contained transparent
@@ -397,9 +478,7 @@ public actual class PlatformGrantDelegate(
             requestViaActivity(allAndroidPermissions.toList())
         }
 
-        mapsMutex.withLock {
-            grants.forEach { statusCacheMap.remove(it.identifier) }
-        }
+        grants.forEach { statusCacheMap.remove(it.identifier) }
 
         return kotlinx.coroutines.coroutineScope {
             grants.map { grant ->
@@ -426,11 +505,31 @@ public actual class PlatformGrantDelegate(
      */
     private suspend fun requestViaActivity(androidPermissions: List<String>) {
         val requestId = GrantRequestActivity.requestGrants(context, androidPermissions)
-        val deferred = GrantRequestActivity.getResultDeferred(requestId) ?: return
+        val deferred = GrantRequestActivity.getResultDeferred(requestId)
+        if (deferred == null) {
+            // Should not happen now that requestGrants() always leaves an entry for the
+            // caller, including on the yield path. Returning quietly here is what previously
+            // turned a lost launch-guard race into a request that silently never prompted,
+            // so it is logged rather than swallowed.
+            GrantLogger.w(
+                TAG,
+                "No pending result for request $requestId — the system dialog was never " +
+                    "shown. Reporting the current status unchanged.",
+            )
+            return
+        }
         try {
             withTimeout(SYSTEM_DIALOG_TIMEOUT_MS) { deferred.await() }
+        } catch (e: TimeoutCancellationException) {
+            // Must be caught BEFORE CancellationException — it is a subclass. This one is our
+            // own timeout firing (the user never answered the dialog), which is a normal
+            // outcome to absorb; a plain CancellationException means the caller's scope died
+            // and must propagate.
+            GrantLogger.e(TAG, "GrantRequestActivity fallback timed out", e)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            GrantLogger.e(TAG, "GrantRequestActivity fallback timeout or error", e)
+            GrantLogger.e(TAG, "GrantRequestActivity fallback error", e)
         } finally {
             GrantRequestActivity.cleanup(requestId)
         }

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/GrantRequestActivityGuardTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/GrantRequestActivityGuardTest.kt
@@ -1,0 +1,106 @@
+package dev.brewkits.grant.impl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the Activity Launch Guard.
+ *
+ * **The defect these pin down:** `cleanup()` used to release the guard unconditionally
+ * (`isActivityActive.set(false)`), even when called by a request that had *lost* the launch
+ * race and never owned it. Two consequences, both reachable by a user tapping two permission
+ * buttons in quick succession:
+ *
+ * 1. The loser freed the winner's guard while the winner's system dialog was still on screen,
+ *    letting a third request launch a second `GrantRequestActivity` over the first.
+ * 2. The loser also removed its own pending entry before returning its id, so the caller's
+ *    `getResultDeferred(id)` came back `null` and `requestViaActivity()` returned silently —
+ *    a `request()` that never showed a dialog and never reported why.
+ *
+ * The guard now records *which* request holds it and releases only on a matching
+ * compare-and-set.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GrantRequestActivityGuardTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @AfterTest
+    fun releaseGuard() {
+        // The guard is process-wide static state; a test that leaves it held would poison the
+        // next one. Draining every id this test class could have created is enough because
+        // each test cleans up the ids it knows about.
+        GrantRequestActivity.forceReleaseGuardForTest()
+    }
+
+    @Test
+    fun a_losing_request_does_not_release_the_guard_held_by_the_winner() = runTest {
+        val winner = GrantRequestActivity.requestGrants(context, listOf("android.permission.CAMERA"))
+        assertTrue(GrantRequestActivity.isAnyActivityActive(), "winner should hold the guard")
+
+        val loser = GrantRequestActivity.requestGrants(context, listOf("android.permission.RECORD_AUDIO"))
+
+        // The loser cleaning up must NOT free a guard it never owned.
+        GrantRequestActivity.cleanup(loser)
+
+        assertTrue(
+            GrantRequestActivity.isAnyActivityActive(),
+            "guard must still be held by the winner after the loser cleaned up — " +
+                "releasing it here is what allowed a second Activity to launch over the first",
+        )
+
+        // Only the owner may release it.
+        GrantRequestActivity.cleanup(winner)
+        assertFalse(GrantRequestActivity.isAnyActivityActive(), "owner's cleanup must release the guard")
+    }
+
+    @Test
+    fun a_losing_request_still_leaves_an_awaitable_result_so_the_caller_never_returns_silently() = runTest {
+        val winner = GrantRequestActivity.requestGrants(context, listOf("android.permission.CAMERA"))
+        val loser = GrantRequestActivity.requestGrants(context, listOf("android.permission.RECORD_AUDIO"))
+
+        val deferred = GrantRequestActivity.getResultDeferred(loser)
+        assertNotNull(
+            deferred,
+            "the losing request must still have a pending entry; returning null here made " +
+                "requestViaActivity() return without ever showing a dialog",
+        )
+        assertEquals(
+            GrantRequestActivity.GrantResult.ERROR,
+            deferred.await(),
+            "a yielded request must resolve to a determinate ERROR, not hang",
+        )
+
+        GrantRequestActivity.cleanup(loser)
+        GrantRequestActivity.cleanup(winner)
+    }
+
+    @Test
+    fun guard_is_released_exactly_once_even_if_cleanup_is_called_repeatedly() = runTest {
+        val owner = GrantRequestActivity.requestGrants(context, listOf("android.permission.CAMERA"))
+        GrantRequestActivity.cleanup(owner)
+        assertFalse(GrantRequestActivity.isAnyActivityActive())
+
+        // A second request takes the guard; the first request's late/duplicate cleanup must
+        // not steal it.
+        val next = GrantRequestActivity.requestGrants(context, listOf("android.permission.RECORD_AUDIO"))
+        GrantRequestActivity.cleanup(owner)
+
+        assertTrue(
+            GrantRequestActivity.isAnyActivityActive(),
+            "a stale cleanup for an already-finished request must not release the new owner's guard",
+        )
+        GrantRequestActivity.cleanup(next)
+    }
+}

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantHandler.kt
@@ -398,6 +398,12 @@ public class GrantHandler(
                 val newStatus = grantManager.request(grant)
                 _status.value = newStatus
                 handleStatus(newStatus, UiStrategy.StateBased(currentRationaleMsg, currentSettingsMsg), isFirstRequest = true)
+            } catch (e: CancellationException) {
+                // Cancellation is not a failure: it means the caller's scope (typically
+                // viewModelScope) is going away. Swallowing it here would let this coroutine
+                // report success and would break structured concurrency for the parent. The
+                // matching guard already exists on request(); it was missing here.
+                throw e
             } catch (e: Exception) {
                 clearCallbacks()
             } finally {

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyServiceManager.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/impl/MyServiceManager.kt
@@ -2,6 +2,7 @@ package dev.brewkits.grant.impl
 
 import dev.brewkits.grant.ServiceManager
 import dev.brewkits.grant.ServiceStatus
+import kotlinx.coroutines.CancellationException
 import dev.brewkits.grant.ServiceType
 
 /**
@@ -17,6 +18,11 @@ public class MyServiceManager internal constructor(
     override suspend fun checkServiceStatus(service: ServiceType): ServiceStatus {
         return try {
             platformDelegate.checkServiceStatus(service)
+        } catch (e: CancellationException) {
+            // Must not be folded into the catch below: cancellation means the caller went
+            // away, not that the service check failed. Reporting UNKNOWN for it would hide a
+            // dead scope behind a plausible-looking value.
+            throw e
         } catch (e: Exception) {
             // If check fails, return UNKNOWN instead of crashing
             ServiceStatus.UNKNOWN
@@ -26,6 +32,8 @@ public class MyServiceManager internal constructor(
     override suspend fun openServiceSettings(service: ServiceType): Boolean {
         return try {
             platformDelegate.openServiceSettings(service)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             false
         }

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/utils/ReentrantMutex.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/utils/ReentrantMutex.kt
@@ -15,51 +15,33 @@ import kotlin.coroutines.coroutineContext
  */
 internal class ReentrantMutex {
     private val mutex = Mutex()
-    private val lock = PlatformLock()
-    private var ownerContext: CoroutineContext? = null
-    private var count = 0
+
+    /**
+     * Whether the underlying mutex is held right now.
+     *
+     * Used only to decide whether a mutex is safe to *discard* when pruning a bounded
+     * per-identifier map — replacing a held mutex would hand two coroutines separate
+     * instances and silently destroy mutual exclusion. It is intentionally not used to
+     * decide whether to lock: that would be a check-then-act race.
+     */
+    val isLocked: Boolean get() = mutex.isLocked
 
     private val key = object : CoroutineContext.Key<MutexElement> {}
 
     private inner class MutexElement : AbstractCoroutineContextElement(key)
 
     suspend fun <T> withLock(block: suspend () -> T): T {
-        val currentContext = coroutineContext
-        
-        val isOwner = lock.withLock {
-            // Check if this mutex is already in the coroutine context
-            if (currentContext[key] != null) {
-                count++
-                true
-            } else {
-                false
-            }
+        // Re-entrancy is decided purely by whether this mutex's marker is present in the
+        // calling coroutine's context. An earlier version also maintained `ownerContext` and
+        // a `count`; neither was ever read to make a decision, and the nested/outer `finally`
+        // blocks could drive `count` negative. Dead state inside a synchronisation primitive
+        // is the worst place for it, so both are gone rather than "fixed".
+        if (coroutineContext[key] != null) {
+            return block()
         }
-        
-        if (isOwner) {
-            return try {
-                block()
-            } finally {
-                lock.withLock { count-- }
-            }
-        }
-        
-        // Use a new context that carries the mutex ownership
-        return kotlinx.coroutines.withContext(currentContext + MutexElement()) {
-            mutex.withLock {
-                lock.withLock {
-                    ownerContext = coroutineContext
-                    count = 1
-                }
-                try {
-                    block()
-                } finally {
-                    lock.withLock {
-                        ownerContext = null
-                        count = 0
-                    }
-                }
-            }
+
+        return kotlinx.coroutines.withContext(coroutineContext + MutexElement()) {
+            mutex.withLock { block() }
         }
     }
 }


### PR DESCRIPTION
## Summary

Findings from a concurrency and performance audit of the Android path, framed against a demanding consumer: a camera app targeting 120 fps and >99.9% crash-free. Every finding below was verified in code, and the critical one has a regression test proven to fail against the old behaviour.

## 🚨 Critical — the launch guard could be freed by a request that never owned it

`GrantRequestActivity`'s guard was an unowned `AtomicBoolean`, and `cleanup()` cleared it unconditionally. A user tapping two permission buttons in quick succession produced:

| Step | Request A (camera) | Request B (mic) | `isActivityActive` |
|---|---|---|---|
| 1 | wins CAS, dialog opens | | `true` |
| 2 | | loses CAS → "Yielding" | `true` |
| 3 | | `cleanup(B)` | **`false`** ← frees A's guard |
| 4 | dialog **still on screen** | | `false` |
| 5 | | request C wins → 2nd Activity | `true` |

Two consequences:

1. **Two `GrantRequestActivity` instances stacked** — two system dialogs, mixed-up results.
2. **A silent no-op, which is worse.** `cleanup(B)` also removed B's own pending entry *before* returning its id, so the caller's `getResultDeferred(id)` came back `null` and `requestViaActivity()` hit a bare `?: return`. A `request()` that never showed a dialog and reported nothing — invisible in Crashlytics. This is exactly the failure class this library exists to prevent.

**Fix:** the guard now records *which* request owns it (`AtomicReference<String?>`), and every release site is a `compareAndSet`. The yield path completes its deferred but leaves the entry for the caller to await, and the should-not-happen branch logs instead of returning quietly.

**Proven, not assumed:** `GrantRequestActivityGuardTest` (3 tests). Restoring the old blind release made **all three fail with `AssertionError`**; restoring the fix makes them pass.

## ⚠️ High

- **Blocking I/O on the main thread.** `SharedPreferencesGrantStore`'s constructor did a SharedPreferences disk read *and* a `PackageManager.getPackageInfo()` binder round trip to `system_server` — on whichever thread built it, which in practice is main (`GrantFactory.create()` from `Application.onCreate()`; Koin `single { }` resolved by the first screen). At a 120 fps budget of ~8 ms, the binder call alone can blow a frame. Now behind `by lazy`, plus a public `warmUp()` to pay the cost off-thread up front. Deliberately blocking and dispatcher-free rather than taking a `CoroutineScope` — coroutines is an `implementation` dependency and does not belong in this module's public ABI.
- **Data races.** `lastActivityLaunchTime` was written from two threads and read unsynchronised; a stale read could satisfy the 60-second staleness check and steal the guard from a live Activity. Now `@Volatile`, as are `launcher` and `notificationStatusCache`.
- **`CancellationException` swallowed** by `catch (e: Exception)` in three places. Each now re-throws it first. **Subtlety worth knowing:** `withTimeout` throws `TimeoutCancellationException`, a *subclass* — it must be caught **before** `CancellationException`, or rethrowing blindly breaks timeout handling. The three `withTimeout` sites in the Android delegate now do exactly that.
- **A global mutex serialising the hot path.** `mapsMutex` guarded two already-thread-safe `ConcurrentHashMap`s, and every `checkStatus()` touched it three times — serialising all permission checks against each other for nothing. `computeIfAbsent` gives the only invariant that mattered; `mapsMutex` is gone.
- **Unbounded maps.** `RawPermission.identifier` is an arbitrary app-supplied string, so both maps could grow without limit. `statusCacheMap` is now an access-order `LinkedHashMap` bounded at 64; `mutexMapInternal` is pruned **only of unlocked entries** — discarding a held mutex would hand two coroutines separate instances and silently destroy mutual exclusion.

## 🟡 Medium

- **Dead state in a synchronisation primitive.** `ReentrantMutex` kept an `ownerContext` never read and a `count` that influenced no decision and could go **negative** across its nested `finally` blocks. Removed rather than "fixed" — re-entrancy was always decided solely by the `CoroutineContext` marker. Added `isLocked`, used by the pruning above.
- **`checkStatus()` was ~90 lines nested five deep.** Split into `resolveRawPermission` / `resolveAppGrant` / `resolveLocationAlways`, with the denial-classification ordering — the heart of Issue #55 and its follow-up — extracted into one `classifyDenial()`. That ordering was previously **duplicated three times**, which is how the copies drifted apart originally. Pure refactor: all 498 Android tests pass unchanged.

## Two audit claims that were wrong, corrected rather than acted on

1. *"Four of six `GrantHandler` paths swallow cancellation"* — three of those four have **no `catch` at all**, so they swallow nothing. Real count: **three**.
2. *"The store's `statusCache` duplicates the delegate's TTL cache"* — it does not. `store.getStatus()` has exactly **one** reader: the branch that runs when no Activity is available to consult `shouldShowRequestPermissionRationale()`, where the last observed status is the only remaining signal for telling `DENIED` from `DENIED_ALWAYS`. Removing it would break that distinction. **Kept**, with a comment so it is not "optimised" away later.

## Verification

- Full root build (`./gradlew build allTests checkKotlinAbi`) green — 1298 tasks.
- `grant-core`: **498** Android unit tests, **423** iOS simulator tests, 0 failures.
- ABI dump regenerated: the only public surface change is the additive `warmUp()`.

## Relationship to other open PRs

Based on `main`, independent of #71 (JS/Wasm) and #72 (macOS Tier 2) — can land in any order.
