### PR TITLE
fix: SCHEDULE_EXACT_ALARM silent no-op (Android) and fabricated GRANTED on iOS 26 (AlarmKit)

### DIFF
--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -346,6 +346,25 @@ public actual class PlatformGrantDelegate(
         var currentStatus = checkStatus(grant)
         if (currentStatus == GrantStatus.GRANTED) return currentStatus
 
+        // SCHEDULE_EXACT_ALARM is NOT a runtime permission — its protectionLevel is
+        // `signature|privileged|appop`, so requestPermissions() can never grant it and shows no
+        // dialog at all. Verified on a real Android 17 device:
+        //   pm grant <pkg> android.permission.SCHEDULE_EXACT_ALARM
+        //   -> SecurityException: ... is not a changeable permission type
+        // (the same command for CAMERA succeeds).
+        //
+        // Before this branch existed, request() fell through to requestPermissions(), nothing
+        // happened, store.setRequested() marked it asked, and the next checkStatus() escalated
+        // it to DENIED_ALWAYS -- sending the user to a Settings page that does not contain the
+        // toggle. That is the exact "dead click" this library exists to prevent (Issue #55),
+        // reproduced inside Grant's own enum.
+        //
+        // The platform's actual request flow for special app access is the dedicated Settings
+        // screen, so that is what "requesting" means here.
+        if (grant == AppGrant.SCHEDULE_EXACT_ALARM && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return requestExactAlarmAccess(currentStatus)
+        }
+
         val allPossiblePermissions = when (grant) {
             is RawPermission -> grant.androidPermissions
             is AppGrant -> grant.toAndroidGrants()
@@ -535,6 +554,42 @@ public actual class PlatformGrantDelegate(
         }
     }
 
+    /**
+     * Sends the user to the "Alarms & reminders" special-access screen, which is the platform's
+     * actual request flow for [AppGrant.SCHEDULE_EXACT_ALARM] — see the call site in
+     * [requestInternal] for why `requestPermissions()` cannot work for it.
+     *
+     * Returns [currentStatus] unchanged: the user is now in Settings and nothing has been
+     * decided yet. This mirrors [openSettings], and like it the host is expected to re-read the
+     * status when the app resumes — `GrantHandler.onReturnFromSettings()` (or `refreshStatus()`)
+     * exists for exactly that. Blocking here to await a Settings round trip would mean guessing
+     * when the user is finished; the resume signal the host already has is the honest one.
+     */
+    private fun requestExactAlarmAccess(currentStatus: GrantStatus): GrantStatus {
+        store.setRequested(AppGrant.SCHEDULE_EXACT_ALARM)
+        statusCacheMap.remove(AppGrant.SCHEDULE_EXACT_ALARM.identifier)
+
+        return try {
+            val intent = android.content.Intent(
+                android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                android.net.Uri.fromParts("package", context.packageName, null)
+            ).apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
+            context.startActivity(intent)
+            GrantLogger.i(
+                TAG,
+                "Opened the exact-alarm settings screen. Re-read the status when your app " +
+                    "resumes (GrantHandler.onReturnFromSettings()); this call cannot observe " +
+                    "the user's choice itself.",
+            )
+            currentStatus
+        } catch (e: Exception) {
+            // Some builds (and most work profiles) do not expose the screen at all. Reporting
+            // the unchanged status and logging beats pretending the request happened.
+            GrantLogger.e(TAG, "Could not open the exact-alarm settings screen", e)
+            currentStatus
+        }
+    }
+
     public actual fun openSettings() {
         try {
             val intent = android.content.Intent(
@@ -543,7 +598,7 @@ public actual class PlatformGrantDelegate(
             ).apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
             context.startActivity(intent)
         } catch (e: Exception) {
-            GrantLogger.e("AndroidGrant", "Failed to open settings", e)
+            GrantLogger.e(TAG, "Failed to open settings", e)
         }
     }
 
@@ -552,8 +607,15 @@ public actual class PlatformGrantDelegate(
             AppGrant.SCHEDULE_EXACT_ALARM -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? android.app.AlarmManager
+                    // DENIED, deliberately not DENIED_ALWAYS. Special app access has no
+                    // permanent-denial state: the toggle stays available in Settings forever and
+                    // Grant can re-open that exact screen on every request (see
+                    // requestExactAlarmAccess). DENIED_ALWAYS would instead drive GrantHandler
+                    // down the settings-guide path, whose openSettings() lands on the app-details
+                    // page -- which does not contain this toggle. DENIED drives the rationale
+                    // path, and re-requesting reopens the correct screen.
                     if (alarmManager != null && alarmManager.canScheduleExactAlarms()) GrantStatus.GRANTED
-                    else if (store.isRequestedBefore(grant)) GrantStatus.DENIED_ALWAYS else GrantStatus.NOT_DETERMINED
+                    else if (store.isRequestedBefore(grant)) GrantStatus.DENIED else GrantStatus.NOT_DETERMINED
                 } else GrantStatus.GRANTED
             }
             AppGrant.NOTIFICATION -> {

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/AndroidDeniedAlwaysTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/AndroidDeniedAlwaysTest.kt
@@ -51,14 +51,28 @@ class AndroidDeniedAlwaysTest {
         assertEquals(GrantStatus.DENIED_ALWAYS, status)
     }
 
+    /**
+     * Expectation deliberately changed from DENIED_ALWAYS to DENIED.
+     *
+     * SCHEDULE_EXACT_ALARM is special app access, not a runtime permission — its
+     * protectionLevel is `signature|privileged|appop` (verified on a real Android 17 device:
+     * `pm grant` rejects it with "not a changeable permission type"). There is therefore no
+     * permanent-denial state: the toggle stays available in Settings forever, and every
+     * request() can reopen that exact screen.
+     *
+     * Reporting DENIED_ALWAYS drove GrantHandler down the settings-guide path, whose
+     * openSettings() lands on the app-details page — which does not contain this toggle, so
+     * the user hit a dead end. DENIED drives the rationale path instead, and re-requesting
+     * reopens the correct screen. This test previously pinned the broken behaviour.
+     */
     @Test
     @Config(sdk = [Build.VERSION_CODES.S])
-    fun `test SCHEDULE_EXACT_ALARM DENIED_ALWAYS logic`() = runBlocking {
+    fun `test SCHEDULE_EXACT_ALARM reports DENIED not DENIED_ALWAYS`() = runBlocking {
         store.setRequested(AppGrant.SCHEDULE_EXACT_ALARM)
-        
+
         val status = delegate.checkStatus(AppGrant.SCHEDULE_EXACT_ALARM)
-        // Default Robolectric behavior for AlarmManager returns false for canScheduleExactAlarms()
-        assertEquals(GrantStatus.DENIED_ALWAYS, status)
+        // Robolectric's AlarmManager shadow returns false for canScheduleExactAlarms().
+        assertEquals(GrantStatus.DENIED, status)
     }
 
     @Test

--- a/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/ExactAlarmRequestTest.kt
+++ b/grant-core/src/androidUnitTest/kotlin/dev/brewkits/grant/impl/ExactAlarmRequestTest.kt
@@ -1,0 +1,96 @@
+package dev.brewkits.grant.impl
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.InMemoryGrantStore
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Regression tests for `request(AppGrant.SCHEDULE_EXACT_ALARM)`.
+ *
+ * **The defect these pin down:** SCHEDULE_EXACT_ALARM is *special app access*, not a runtime
+ * permission — its protectionLevel is `signature|privileged|appop`. Proven on a real Android 17
+ * device against this project's own demo package:
+ *
+ * ```
+ * $ adb shell pm grant dev.brewkits.grant.demo android.permission.SCHEDULE_EXACT_ALARM
+ * SecurityException: ... is not a changeable permission type
+ * $ adb shell pm grant dev.brewkits.grant.demo android.permission.CAMERA
+ * (succeeds)
+ * ```
+ *
+ * `requestPermissions()` therefore shows no dialog and can never grant it. Before the fix,
+ * `request()` fell through to exactly that call: nothing happened, the store recorded the
+ * permission as asked, and the next `checkStatus()` escalated it to DENIED_ALWAYS — sending the
+ * user to a Settings page that does not contain the toggle. A silent no-op ending in a dead
+ * end, which is the failure class this library exists to prevent (Issue #55).
+ *
+ * The platform's real request flow for special app access is the dedicated Settings screen, so
+ * that is what `request()` must open.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class ExactAlarmRequestTest {
+
+    private lateinit var context: Context
+    private lateinit var delegate: PlatformGrantDelegate
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        delegate = PlatformGrantDelegate(context, InMemoryGrantStore())
+    }
+
+    private fun nextStartedIntentAction(): String? =
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .nextStartedActivity
+            ?.action
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun `request opens the exact-alarm settings screen instead of silently doing nothing`() = runBlocking {
+        delegate.request(AppGrant.SCHEDULE_EXACT_ALARM)
+
+        val action = nextStartedIntentAction()
+        assertNotNull(
+            action,
+            "request(SCHEDULE_EXACT_ALARM) must start an Activity; starting nothing is the " +
+                "silent no-op this test exists to prevent",
+        )
+        assertEquals(
+            Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+            action,
+            "must open the Alarms & reminders screen, not the app-details page — the toggle " +
+                "does not exist on app details",
+        )
+    }
+
+    /**
+     * Below API 31 the permission does not exist and `canScheduleExactAlarms()` has no
+     * counterpart, so the status override reports GRANTED and `request()` must return before
+     * doing anything at all — no Settings screen, no prompt.
+     */
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun `request is a no-op below API 31 where the permission does not exist`() = runBlocking {
+        delegate.request(AppGrant.SCHEDULE_EXACT_ALARM)
+
+        assertNull(
+            nextStartedIntentAction(),
+            "nothing should be launched on API 30 — exact-alarm access is not gated there",
+        )
+    }
+}

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
@@ -51,7 +51,8 @@ private const val TAG = "iOSGrantDelegate"
  * - Calendar            — EventKit
  * - Motion              — CoreMotion
  * - Bluetooth           — CoreBluetooth (via BluetoothManagerDelegate)
- * - Schedule Exact Alarm — always GRANTED on iOS
+ * - Schedule Exact Alarm — GRANTED unless the app declares NSAlarmKitUsageDescription;
+ *   see ExactAlarmHandler for why AlarmKit (iOS 26+) cannot be answered from here
  *
  * **Thread Safety:**
  * - [mutexMap] is protected by [mapsMutex]
@@ -298,7 +299,9 @@ public actual class PlatformGrantDelegate(
         AppGrant.BLUETOOTH,
         AppGrant.BLUETOOTH_ADVERTISE  -> getOptionalHandler(grant, "dev.brewkits:grant-bluetooth", "GrantBluetooth.initialize()")
 
-        AppGrant.SCHEDULE_EXACT_ALARM,
+        // Registry first, so an app that bridges AlarmKit itself wins over the fallback below.
+        AppGrant.SCHEDULE_EXACT_ALARM -> IosPermissionHandlerRegistry.get(grant.identifier) ?: ExactAlarmHandler
+
         AppGrant.NEARBY_WIFI_DEVICES,
         // iOS has no API to query or explicitly request local-network authorization — the
         // OS prompts on the first LAN access when NSLocalNetworkUsageDescription is present.
@@ -328,11 +331,66 @@ public actual class PlatformGrantDelegate(
 
 /**
  * A no-op handler for permissions that iOS always grants without a dialog
- * (e.g., [AppGrant.SCHEDULE_EXACT_ALARM]).
+ * (e.g., [AppGrant.NEARBY_WIFI_DEVICES]).
  */
 private object AlwaysGrantedHandler : PermissionHandler {
     override fun checkStatus(): GrantStatus = GrantStatus.GRANTED
     override suspend fun request(): GrantStatus = GrantStatus.GRANTED
+}
+
+/** `Info.plist` key an app declares when it uses AlarmKit (iOS 26+). */
+private const val ALARMKIT_USAGE_KEY = "NSAlarmKitUsageDescription"
+
+/**
+ * Handles [AppGrant.SCHEDULE_EXACT_ALARM] on iOS, where the honest answer depends on whether
+ * the app uses AlarmKit.
+ *
+ * **Until iOS 25** nothing on iOS gated scheduling: a local notification via
+ * `UNUserNotificationCenter` needs only the notification permission Grant already models, so
+ * reporting GRANTED here was correct and remains correct for those apps.
+ *
+ * **iOS 26 introduced AlarmKit**, which *is* consent-gated — the SDK exposes
+ * `requestAuthorization`, `authorizationState` and `AlarmAuthorizationState`, and the runtime
+ * defines [ALARMKIT_USAGE_KEY]. For an app using it, an unconditional GRANTED is a fabricated
+ * status: the user may never have authorized alarms. That is the failure mode this library
+ * exists to prevent, so it is not shipped here either.
+ *
+ * **Grant cannot query AlarmKit itself.** Verified against the iOS 26.5 SDK: AlarmKit's
+ * `Headers/AlarmKit.h` is an umbrella header carrying only version symbols — the whole API
+ * lives in `.swiftinterface`, so there is no Objective-C surface for Kotlin/Native cinterop to
+ * bind. Claiming support would be presence without function.
+ *
+ * So the plist key is used as the signal for "this app uses AlarmKit":
+ * - key absent (the overwhelming majority) → GRANTED, unchanged behaviour
+ * - key present → DENIED_ALWAYS with a log pointing at the escape hatch, matching the
+ *   convention the web and JVM delegates already follow for permissions the platform cannot
+ *   back. An app that needs a real answer registers its own Swift-bridged handler through
+ *   [IosPermissionHandlerRegistry], which takes precedence over this one.
+ */
+private object ExactAlarmHandler : PermissionHandler {
+
+    private fun resolve(): GrantStatus {
+        // Read the bundle directly rather than through hasInfoPlistKey(): that helper logs an
+        // ERROR when a key is absent, which is right where a key is required, but here absence
+        // is the normal, correct case for almost every app.
+        val usesAlarmKit = NSBundle.mainBundle.objectForInfoDictionaryKey(ALARMKIT_USAGE_KEY) != null
+        if (!usesAlarmKit) return GrantStatus.GRANTED
+
+        GrantLogger.w(
+            TAG,
+            "$ALARMKIT_USAGE_KEY is declared, so this app uses AlarmKit — which iOS 26 gates " +
+                "behind user authorization. Grant cannot read that state: AlarmKit is a " +
+                "Swift-only framework with no Objective-C surface for Kotlin/Native. Reporting " +
+                "DENIED_ALWAYS rather than a GRANTED this platform cannot back. To get a real " +
+                "answer, implement PermissionHandler over AlarmKit in your iOS code and " +
+                "register it via IosPermissionHandlerRegistry.register(" +
+                "AppGrant.SCHEDULE_EXACT_ALARM.identifier, yourHandler).",
+        )
+        return GrantStatus.DENIED_ALWAYS
+    }
+
+    override fun checkStatus(): GrantStatus = resolve()
+    override suspend fun request(): GrantStatus = resolve()
 }
 
 /**

--- a/grant-core/src/iosTest/kotlin/dev/brewkits/grant/IosGrantDelegateTest.kt
+++ b/grant-core/src/iosTest/kotlin/dev/brewkits/grant/IosGrantDelegateTest.kt
@@ -128,11 +128,27 @@ class IosGrantDelegateTest {
         assertValidStatus(AppGrant.BLUETOOTH_ADVERTISE)
     }
 
+    /**
+     * GRANTED here is conditional, not unconditional — this test bundle declares no
+     * `NSAlarmKitUsageDescription`, which is the case for the overwhelming majority of apps and
+     * the one this pins: scheduling a local notification needs no separate iOS permission, so
+     * GRANTED is the honest answer and must not regress.
+     *
+     * An app that *does* declare that key uses AlarmKit, which iOS 26 gates behind user
+     * authorization; `ExactAlarmHandler` reports DENIED_ALWAYS there rather than a status Grant
+     * cannot back (AlarmKit is Swift-only, so Kotlin/Native cannot query it). That branch is
+     * deliberately not covered here: it depends on the *host bundle's* Info.plist, which a unit
+     * test running inside the test bundle cannot vary. It is exercised by declaring the key in
+     * a real app, and the code path is a single `objectForInfoDictionaryKey` read.
+     */
     @Test
-    fun `checkStatus SCHEDULE_EXACT_ALARM returns GRANTED on iOS`() = kotlinx.coroutines.test.runTest {
-        // iOS has no concept of exact alarm permission — always GRANTED
+    fun `checkStatus SCHEDULE_EXACT_ALARM returns GRANTED when the app does not use AlarmKit`() = kotlinx.coroutines.test.runTest {
         val status = delegate.checkStatus(AppGrant.SCHEDULE_EXACT_ALARM)
-        assertEquals(GrantStatus.GRANTED, status, "SCHEDULE_EXACT_ALARM must always be GRANTED on iOS")
+        assertEquals(
+            GrantStatus.GRANTED,
+            status,
+            "without NSAlarmKitUsageDescription there is nothing on iOS to gate scheduling",
+        )
     }
 
 


### PR DESCRIPTION
## Summary

Two defects in `AppGrant.SCHEDULE_EXACT_ALARM`, one per platform, found while auditing coverage against the newest OS releases. Both were verified against ground truth — a connected **Android 17 (API 37)** device and the **iOS 26.5** SDK/runtime — not from recall.

Both are the same failure class the library exists to prevent: reporting a status the platform does not actually back.

## 🚨 Android — `request()` showed nothing, then blamed the user

`SCHEDULE_EXACT_ALARM` is **special app access, not a runtime permission**. Proven on a real API 37 device against this project's own demo package:

```
$ adb shell pm grant dev.brewkits.grant.demo android.permission.SCHEDULE_EXACT_ALARM
SecurityException: ... is not a changeable permission type      ← protectionLevel signature|privileged|appop

$ adb shell pm grant dev.brewkits.grant.demo android.permission.CAMERA
(succeeds)                                                       ← control
```

`checkStatus()` was **already correct** (reads `AlarmManager.canScheduleExactAlarms()`). `request()` had no special case and fell through to `requestPermissions()`:

```
request() → no dialog, nothing happens
         → store.setRequested() records it as asked
         → next checkStatus() → DENIED_ALWAYS
         → app shows "open Settings" → app-details page → toggle is not there
         → dead end
```

**Fixes:**
- `request()` opens `Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM` — that *is* the platform's request flow for special app access. It returns the unchanged status and logs that the host must re-read on resume, the same contract `openSettings()` already has and `GrantHandler.onReturnFromSettings()` already serves.
- Status override reports **`DENIED`, not `DENIED_ALWAYS`**. Special app access has no permanent-denial state — the toggle stays available forever and every `request()` can reopen that screen. `DENIED_ALWAYS` drove `GrantHandler` down the settings-guide path (wrong screen); `DENIED` drives the rationale path, and re-requesting reopens the right one.

## 🚨 iOS — `GRANTED` became fabricated when iOS 26 shipped AlarmKit

The handler was `AlwaysGrantedHandler`. Correct through iOS 25, where nothing gated scheduling. **iOS 26 introduced AlarmKit**, which is consent-gated: the 26.5 SDK exposes `requestAuthorization` / `authorizationState` / `AlarmAuthorizationState`, and the runtime defines `NSAlarmKitUsageDescription`.

**Grant cannot query AlarmKit — verified, not assumed:** `AlarmKit.framework/Headers/AlarmKit.h` is an umbrella header carrying only version symbols; the entire API lives in `.swiftinterface`. There is no Objective-C surface for Kotlin/Native cinterop to bind. Claiming support would be presence without function.

So the plist key is the signal for "this app uses AlarmKit":

| `NSAlarmKitUsageDescription` | Result |
|---|---|
| absent (almost every app) | `GRANTED` — unchanged; scheduling a local notification needs no separate iOS permission |
| present | `DENIED_ALWAYS` + a log pointing at `IosPermissionHandlerRegistry` |

That matches the convention the web and JVM delegates already follow. A registered handler still takes precedence, so an app that bridges AlarmKit in Swift gets a real answer.

The bundle is read directly rather than via `hasInfoPlistKey()` — that helper logs an ERROR on absence, which is right where a key is *required*, but here absence is the normal case for nearly every app.

## Tests

- **`ExactAlarmRequestTest` (new)** pins that `request()` starts `ACTION_REQUEST_SCHEDULE_EXACT_ALARM` on API 31+, and starts **nothing** on API 30 where the permission does not exist. **Confirmed it bites:** restoring the pre-fix fall-through makes it fail.
- **`AndroidDeniedAlwaysTest` asserted `DENIED_ALWAYS`** — it was pinning the broken behaviour. Updated to `DENIED`, with the reasoning recorded in the test.
- **The iOS test asserted "must always be GRANTED"** — no longer the contract. Renamed and documented to say what it actually pins, and why the other branch cannot be unit-tested (it depends on the *host bundle's* `Info.plist`, which a test running inside the test bundle cannot vary).

## Verification

Full root build (`build allTests checkKotlinAbi`) green. grant-core: **499** Android unit tests, **423** iOS simulator tests, 0 failures. **No public API change** — `checkKotlinAbi` unchanged.

## Not in this PR

The audit's third finding — `NSCalendarsWriteOnlyAccessUsageDescription` (iOS 17+) missing from the calendar plist gate, causing a false `DENIED_ALWAYS` — lands in **#70** instead, which already refactors that exact function. Keeping it there avoids a guaranteed conflict between the two PRs.
