### PR TITLE
feat: App Tracking Transparency as an opt-in grant-tracking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fun CameraScreen(viewModel: CameraViewModel) {
 - **iOS crash guard** — validates `Info.plist` keys before requesting, turning the classic `SIGABRT` production crash into a clear error.
 - **Android process-death recovery** — a request in flight survives system-initiated process death via `SavedStateHandle`, with no timeouts.
 - **Deadlock-free by construction** — reentrant locking plus a `withTimeout` test policy that converts silent deadlocks into failing tests.
-- **20 built-in permissions** — Camera, Gallery (incl. Android 14 partial access and a save-only mode that never prompts), Location (incl. "Approximate"-only), Bluetooth, Local Network (Android 17), and more — plus `RawPermission` for anything the library doesn't ship yet.
+- **21 built-in permissions** — Camera, Gallery (incl. Android 14 partial access and a save-only mode that never prompts), Location (incl. "Approximate"-only), Bluetooth, Local Network (Android 17), App Tracking Transparency (iOS), and more — plus `RawPermission` for anything the library doesn't ship yet.
 - **Permission groups as one unit** — `GrantGroupHandler` requests several permissions in a single batch, drives one `StateFlow` for the whole group, and fires `onAllGranted` only when every one is satisfied.
 - **Funnel analytics** — attach an optional `GrantEventListener` to any handler and observe every stage: requested, granted, denied, rationale shown, settings guide shown, settings opened.
 - **Service-state checks** — one call answers both "is the permission granted?" and "is GPS/Bluetooth actually on?".
@@ -256,7 +256,7 @@ ceremony, not speed.
 
 ## Supported permissions
 
-20 built-in permissions across Camera, Microphone, Gallery (read and save-only), Storage, Location, Notifications, Bluetooth, Contacts, Calendar, Motion, Exact Alarms, Nearby Wi-Fi, and Local Network — anything else via `RawPermission`.
+21 built-in permissions across Camera, Microphone, Gallery (read and save-only), Storage, Location, Notifications, Bluetooth, Contacts, Calendar, Motion, Exact Alarms, Nearby Wi-Fi, Local Network, and App Tracking Transparency — anything else via `RawPermission`.
 
 <details>
 <summary><strong>Full permission matrix</strong></summary>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,6 +170,26 @@ just unit tests.
 
 **Explicitly out of scope, with reasons** (so it isn't re-litigated by assumption): Linux desktop (no reliable cross-environment signal), watchOS/tvOS (different problem shape, stays in Backlog below), standalone Kotlin/Native `macosArm64`/`macosX64` klib target (can't be consumed by a Compose Desktop app — this is what `grant-desktop`'s `.dylib`-over-JNA approach sidesteps).
 
+### v2.7.0 — Newest-OS permission coverage
+
+*Origin: an audit of coverage against the newest OS releases, grounded in a connected Android 17 (API 37) device (`pm list permissions -d`, `pm grant`) and the iOS 26.5 SDK/runtime rather than recall. It produced three defect fixes (shipped in #70 and #74) and one genuine gap, below.*
+
+**1. App Tracking Transparency** ✅ *shipped as `grant-tracking`*
+- [x] `AppGrant.APP_TRACKING` (21st permission), backed on iOS by `ATTrackingManager` in a **new opt-in module**. The module boundary is forced, not stylistic: linking `AppTrackingTransparency.framework` makes Apple require `NSUserTrackingUsageDescription` in *every* app that links it, so `grant-core` must not — the same isolation reason as `grant-contacts`/`grant-calendar`/`grant-motion` (Issues #38, #45).
+- [x] Feasibility verified before writing code, the same check that ruled AlarmKit out: `AppTrackingTransparency.framework/Headers/ATTrackingManager.h` is a real Objective-C header exposing `trackingAuthorizationStatus`, `requestTrackingAuthorizationWithCompletionHandler:` and the 0–3 status enum, so Kotlin/Native cinterop can bind it.
+- [x] `restricted` and `denied` both map to `DENIED_ALWAYS` but are logged distinctly, because the remedy differs: `denied` is recoverable in *this app's* settings, `restricted` is a device-wide switch or MDM profile that the app's own settings page cannot change — sending the user there would be a dead end.
+- [x] `request()` warns when the app is not foreground-**active**. iOS shows the ATT prompt only in that state; called during launch or from the background it returns the current status with no prompt, and the one ask an install gets is spent. Grant cannot defer the call without guessing a good moment, so it warns rather than silently burning the ask.
+- [x] Android is a documented no-op reporting GRANTED — honest, not a stub: cross-app tracking is gated there by `com.google.android.gms.permission.AD_ID`, an *install-time* permission with no runtime prompt to show. Users opt out in system settings, which surfaces as a zeroed advertising ID rather than a permission denial Grant could observe.
+- [ ] **Not yet verified on a device.** The status mapping and the foreground-active rule are unit-untestable — `trackingAuthorizationStatus` reads real TCC state a test cannot set, and the prompt needs a human. Must be exercised on a real device before this module is advertised as verified.
+
+**2. Health Connect (Android)** — *not started*
+- [ ] ~200 `android.permission.health.*` permissions exist on API 37. They deliberately do **not** go through `requestPermissions()`: they need `PermissionController.createRequestPermissionResultContract()` plus a rationale activity declared with the `androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE` intent filter. A `RawPermission` would therefore fail silently, which is why this is a real gap rather than something consumers can already work around.
+- [ ] It also does not fit the `AppGrant` model — modelling 200 enum values would be wrong. Needs its own permission type and its own module; design first, code after.
+
+**Deliberately left to `RawPermission`** (all confirmed `dangerous` on API 37, so `checkStatus`/`request` already work on Android today): `READ_MEDIA_AUDIO`, `ACCESS_MEDIA_LOCATION`, `GET_ACCOUNTS`, `BODY_SENSORS`(+`_BACKGROUND`), `RANGING`, `UWB_RANGING`, and the SMS / phone / call-log families. Worth noting in docs that `ACCESS_MEDIA_LOCATION` is the companion to gallery reads (GPS in EXIF) and is **not** auto-granted with `READ_MEDIA_IMAGES`.
+
+**Note on the `RawPermission` escape hatch — it is not symmetric.** On Android it is complete: `checkStatus()` and `request()` both work for any dangerous permission. On iOS `request()` **cannot** work — there is no generic request API, so it logs and returns `NOT_DETERMINED`; the only real route is implementing `PermissionHandler` and registering it via `IosPermissionHandlerRegistry`. So "missing permission X" is a documentation matter on Android and a real gap on iOS.
+
 ## 📋 Backlog / Considering
 
 *Not committed to a version yet — pulled into a milestone when a consumer actually asks.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,9 +182,27 @@ just unit tests.
 - [x] Android is a documented no-op reporting GRANTED — honest, not a stub: cross-app tracking is gated there by `com.google.android.gms.permission.AD_ID`, an *install-time* permission with no runtime prompt to show. Users opt out in system settings, which surfaces as a zeroed advertising ID rather than a permission denial Grant could observe.
 - [ ] **Not yet verified on a device.** The status mapping and the foreground-active rule are unit-untestable — `trackingAuthorizationStatus` reads real TCC state a test cannot set, and the prompt needs a human. Must be exercised on a real device before this module is advertised as verified.
 
-**2. Health Connect (Android)** — *not started*
-- [ ] ~200 `android.permission.health.*` permissions exist on API 37. They deliberately do **not** go through `requestPermissions()`: they need `PermissionController.createRequestPermissionResultContract()` plus a rationale activity declared with the `androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE` intent filter. A `RawPermission` would therefore fail silently, which is why this is a real gap rather than something consumers can already work around.
-- [ ] It also does not fit the `AppGrant` model — modelling 200 enum values would be wrong. Needs its own permission type and its own module; design first, code after.
+**2. Health Connect (Android)** — *deferred: blocked on a design decision, not on effort*
+
+*Deliberately not started. The investigation below is the deliverable for now — it turns out this is an architecture choice with real trade-offs, and picking one unilaterally would have shaped the library in a way that is expensive to undo.*
+
+**Why `RawPermission` cannot absorb this** (unlike every other uncovered Android permission): the ~200 `android.permission.health.*` permissions on API 37 do **not** go through `requestPermissions()` at all. They need `PermissionController.createRequestPermissionResultContract()`, plus a rationale Activity declared with the `androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE` intent filter. A `RawPermission` routed through the normal path would fail *silently* — the failure mode this library exists to prevent.
+
+**Two constraints in the current design force the choice** (both verified in code):
+1. **`GrantPermission` is `sealed`.** A `grant-health` module cannot add a new permission type; only `grant-core` can. Modelling ~200 `AppGrant` enum values is obviously wrong, so a new type is what this actually needs.
+2. **Android has no handler registry.** iOS has `IosPermissionHandlerRegistry` and the JVM has `DesktopPermissionHandlerRegistry`, but `PlatformGrantDelegate.android.kt` resolves everything inline. There is no extension point for an opt-in Android module to plug into.
+
+**Option A — add an Android handler registry to `grant-core`.**
+Consistent with iOS and JVM, and `grant-health` would then register into it like `grant-contacts` does. Consumers keep the unified `GrantManager` / `GrantHandler` surface: one state machine, one rationale flow, one settings guide.
+*Cost:* new public API in `grant-core`'s Android surface, which every consumer inherits and the ABI gate then locks in. Also unresolved: Health Connect's flow is `ActivityResultContract`-based, so it must reach a host Activity — whether the existing `GrantLauncher` abstraction covers that shape, or needs widening, has not been established.
+
+**Option B — `grant-health` exposes its own API, bypassing `GrantManager`.**
+Zero blast radius on `grant-core`; nothing to undo if Health Connect's contract changes again.
+*Cost:* honest but inconsistent — consumers lose `GrantHandler`'s state machine, rationale and settings-guide handling for health permissions specifically, and have to hand-roll that UX. Two ways to ask for a permission in one library is its own kind of confusion.
+
+**A third constraint that neither option removes:** the consuming app must declare the rationale Activity and (Android 14+) the `<queries>` entry for the Health Connect package in *its own* manifest. A library cannot do that on an app's behalf — the manifest-merger reasons this project already documented for `<uses-permission>` apply here too. So whichever option is chosen, Health Connect will always require setup steps in the host app that no other `AppGrant` needs.
+
+**Recommendation if this is picked up:** start from a real consumer asking for it, and prefer **A** only if that consumer wants the unified handler UX; otherwise **B** is the smaller, more reversible bet. This is also, on current evidence, the least urgent item here — no issue has ever requested it, and it is irrelevant to camera/media apps, which is where Grant's coverage is strongest.
 
 **Deliberately left to `RawPermission`** (all confirmed `dangerous` on API 37, so `checkStatus`/`request` already work on Android today): `READ_MEDIA_AUDIO`, `ACCESS_MEDIA_LOCATION`, `GET_ACCOUNTS`, `BODY_SENSORS`(+`_BACKGROUND`), `RANGING`, `UWB_RANGING`, and the SMS / phone / call-log families. Worth noting in docs that `ACCESS_MEDIA_LOCATION` is the companion to gallery reads (GPS in EXIF) and is **not** auto-granted with `READ_MEDIA_IMAGES`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     dokka(project(":grant-motion"))
     dokka(project(":grant-bluetooth"))
     dokka(project(":grant-location-always"))
+    dokka(project(":grant-tracking"))
     dokka(project(":grant-desktop"))
 }
 

--- a/create-grant-maven-bundle-auto.sh
+++ b/create-grant-maven-bundle-auto.sh
@@ -26,6 +26,7 @@ MODULES=(
     grant-motion
     grant-bluetooth
     grant-location-always
+    grant-tracking
 )
 
 echo "=========================================="

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,6 +48,7 @@ kotlin {
             implementation("dev.brewkits:grant-motion:2.3.0")          // Optional: Motion (iOS CoreMotion)
             implementation("dev.brewkits:grant-bluetooth:2.3.0")       // Optional: Bluetooth (iOS CoreBluetooth)
             implementation("dev.brewkits:grant-location-always:2.3.0") // Optional: background "always" location (iOS requestAlwaysAuthorization)
+            implementation("dev.brewkits:grant-tracking:2.3.0")        // Optional: App Tracking Transparency (iOS ATTrackingManager)
         }
     }
 }
@@ -65,6 +66,7 @@ kotlin {
 | `grant-motion` | Your app uses motion / activity recognition (links iOS `CoreMotion.framework`). |
 | `grant-bluetooth` | Your app uses Bluetooth (links iOS `CoreBluetooth.framework`). |
 | `grant-location-always` | Your app needs background ("always") location (links iOS `requestAlwaysAuthorization`). |
+| `grant-tracking` | Your app asks for cross-app tracking consent — ad attribution or measurement (links iOS `AppTrackingTransparency`, which makes Apple require `NSUserTrackingUsageDescription`). No-op on Android, which has no runtime permission for this. |
 
 > **Why the optional split?** On iOS, Apple's static scanner flags any linked
 > framework and requires the matching `NSUsageDescription` key. By keeping these
@@ -107,6 +109,7 @@ See [GRANTS.md](../grant-core/GRANTS.md) for the full permission → manifest ma
    GrantMotion.shared.initialize()          // if you added grant-motion
    GrantBluetooth.shared.initialize()       // if you added grant-bluetooth
    GrantLocationAlways.shared.initialize()  // if you added grant-location-always
+   GrantTracking.shared.initialize()        // if you added grant-tracking
    ```
 
    `grant-core` permissions (Camera, foreground Location, Gallery, Microphone,

--- a/grant-core/api/android/grant-core.api
+++ b/grant-core/api/android/grant-core.api
@@ -6,6 +6,7 @@ public final class dev/brewkits/grant/AndroidSavedStateDelegate : dev/brewkits/g
 }
 
 public class dev/brewkits/grant/AppGrant : java/lang/Enum, dev/brewkits/grant/GrantPermission {
+	public static final field APP_TRACKING Ldev/brewkits/grant/AppGrant;
 	public static final field BLUETOOTH Ldev/brewkits/grant/AppGrant;
 	public static final field BLUETOOTH_ADVERTISE Ldev/brewkits/grant/AppGrant;
 	public static final field CALENDAR Ldev/brewkits/grant/AppGrant;

--- a/grant-core/api/grant-core.klib.api
+++ b/grant-core/api/grant-core.klib.api
@@ -51,6 +51,7 @@ final enum class dev.brewkits.grant/ServiceType : kotlin/Enum<dev.brewkits.grant
 }
 
 open enum class dev.brewkits.grant/AppGrant : dev.brewkits.grant/GrantPermission, kotlin/Enum<dev.brewkits.grant/AppGrant> { // dev.brewkits.grant/AppGrant|null[0]
+    enum entry APP_TRACKING // dev.brewkits.grant/AppGrant.APP_TRACKING|null[0]
     enum entry BLUETOOTH // dev.brewkits.grant/AppGrant.BLUETOOTH|null[0]
     enum entry BLUETOOTH_ADVERTISE // dev.brewkits.grant/AppGrant.BLUETOOTH_ADVERTISE|null[0]
     enum entry CALENDAR // dev.brewkits.grant/AppGrant.CALENDAR|null[0]

--- a/grant-core/api/jvm/grant-core.api
+++ b/grant-core/api/jvm/grant-core.api
@@ -1,4 +1,5 @@
 public class dev/brewkits/grant/AppGrant : java/lang/Enum, dev/brewkits/grant/GrantPermission {
+	public static final field APP_TRACKING Ldev/brewkits/grant/AppGrant;
 	public static final field BLUETOOTH Ldev/brewkits/grant/AppGrant;
 	public static final field BLUETOOTH_ADVERTISE Ldev/brewkits/grant/AppGrant;
 	public static final field CALENDAR Ldev/brewkits/grant/AppGrant;

--- a/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
+++ b/grant-core/src/androidMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.android.kt
@@ -719,6 +719,13 @@ public actual class PlatformGrantDelegate(
             // "targets 36, runs on 17" is the norm for roughly a year after each release.
             //
             // Either condition failing → empty list → checkStatus reports GRANTED (no-op).
+            // Android has no runtime permission for cross-app tracking. The advertising ID is
+            // gated by com.google.android.gms.permission.AD_ID, which is install-time (normal)
+            // — auto-granted, with no dialog to show. An empty list makes checkStatus report
+            // GRANTED without prompting, which is honest: the OS does not gate this at runtime.
+            // Users opt out in system settings, and that surfaces as a zeroed advertising ID,
+            // not as a permission denial Grant could observe.
+            AppGrant.APP_TRACKING -> emptyList()
             AppGrant.LOCAL_NETWORK ->
                 if (Build.VERSION.SDK_INT >= 37 && targetSdkVersion >= 37) listOf(ACCESS_LOCAL_NETWORK)
                 else emptyList()

--- a/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantType.kt
+++ b/grant-core/src/commonMain/kotlin/dev/brewkits/grant/GrantType.kt
@@ -198,7 +198,30 @@ public enum class AppGrant : GrantPermission {
      *   local-network authorization; the OS prompts automatically on the first LAN access
      *   when `NSLocalNetworkUsageDescription` is present in Info.plist.
      */
-    LOCAL_NETWORK;
+    LOCAL_NETWORK,
+
+    /**
+     * Permission to track the user across apps and websites owned by other companies —
+     * advertising attribution, cross-app analytics, ad measurement.
+     *
+     * - **iOS**: App Tracking Transparency (`ATTrackingManager`), requiring
+     *   `NSUserTrackingUsageDescription`. **Needs the opt-in `dev.brewkits:grant-tracking`
+     *   module** and a `GrantTracking.initialize()` call: linking
+     *   `AppTrackingTransparency.framework` makes Apple demand that usage-description key,
+     *   so `grant-core` must not link it for apps that do not track. Same isolation reason as
+     *   `grant-contacts`/`grant-calendar`/`grant-motion` (Issues #38, #45).
+     * - **Android**: No-op (always GRANTED). Android gates the advertising ID with
+     *   `com.google.android.gms.permission.AD_ID`, which is an *install-time* permission —
+     *   auto-granted, with no runtime prompt to show. Reporting GRANTED is honest here: the
+     *   OS genuinely does not gate this at runtime. Users opt out through system settings,
+     *   which surfaces as a zeroed advertising ID rather than a permission denial.
+     *
+     * **Timing matters on iOS.** The system only shows the prompt while the app is
+     * foreground-*active*; requesting during launch or from the background returns the current
+     * status with no prompt shown, and the ask is silently spent. Request it from a screen the
+     * user is actually looking at.
+     */
+    APP_TRACKING;
 
     /**
      * Unique identifier for this permission.

--- a/grant-core/src/commonTest/kotlin/dev/brewkits/grant/GrantTypeTest.kt
+++ b/grant-core/src/commonTest/kotlin/dev/brewkits/grant/GrantTypeTest.kt
@@ -9,7 +9,7 @@ class GrantTypeTest {
     @Test
     fun testAllGrantTypesExist() {
         val grants = AppGrant.entries
-        assertEquals(20, grants.size, "Expected 20 grant types")
+        assertEquals(21, grants.size, "Expected 21 grant types")
     }
 
     @Test
@@ -28,6 +28,7 @@ class GrantTypeTest {
         assertTrue(grants.contains(AppGrant.BLUETOOTH), "BLUETOOTH grant should exist")
         assertTrue(grants.contains(AppGrant.BLUETOOTH_ADVERTISE), "BLUETOOTH_ADVERTISE grant should exist")
         assertTrue(grants.contains(AppGrant.MICROPHONE), "MICROPHONE grant should exist")
+        assertTrue(grants.contains(AppGrant.APP_TRACKING), "APP_TRACKING grant should exist")
         assertTrue(grants.contains(AppGrant.CONTACTS), "CONTACTS grant should exist")
         assertTrue(grants.contains(AppGrant.READ_CONTACTS), "READ_CONTACTS grant should exist")
         assertTrue(grants.contains(AppGrant.MOTION), "MOTION grant should exist")

--- a/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
+++ b/grant-core/src/iosMain/kotlin/dev/brewkits/grant/impl/PlatformGrantDelegate.ios.kt
@@ -296,6 +296,11 @@ public actual class PlatformGrantDelegate(
 
         AppGrant.MOTION               -> getOptionalHandler(grant, "dev.brewkits:grant-motion", "GrantMotion.initialize()")
 
+        // AppTrackingTransparency is isolated for the same reason Contacts/EventKit/CoreMotion
+        // are: linking it makes Apple require NSUserTrackingUsageDescription in every consuming
+        // app, including ones that never track (Issues #38, #45).
+        AppGrant.APP_TRACKING         -> getOptionalHandler(grant, "dev.brewkits:grant-tracking", "GrantTracking.initialize()")
+
         AppGrant.BLUETOOTH,
         AppGrant.BLUETOOTH_ADVERTISE  -> getOptionalHandler(grant, "dev.brewkits:grant-bluetooth", "GrantBluetooth.initialize()")
 

--- a/grant-core/src/iosTest/kotlin/dev/brewkits/grant/handlers/IosHandlerPatternTest.kt
+++ b/grant-core/src/iosTest/kotlin/dev/brewkits/grant/handlers/IosHandlerPatternTest.kt
@@ -112,10 +112,15 @@ private object IosHandlerDispatchValidator {
 
         AppGrant.MOTION               -> stubHandler("MOTION")
 
+        AppGrant.APP_TRACKING         -> stubHandler("APP_TRACKING")
+
         AppGrant.BLUETOOTH,
         AppGrant.BLUETOOTH_ADVERTISE  -> stubHandler("BLUETOOTH")
 
-        AppGrant.SCHEDULE_EXACT_ALARM,
+        // Its own handler since #74 — GRANTED only when the app does not declare
+        // NSAlarmKitUsageDescription; see ExactAlarmHandler.
+        AppGrant.SCHEDULE_EXACT_ALARM -> stubHandler("EXACT_ALARM")
+
         AppGrant.NEARBY_WIFI_DEVICES,
         AppGrant.LOCAL_NETWORK        -> stubHandler("ALWAYS_GRANTED")
     }

--- a/grant-tracking/api/android/grant-tracking.api
+++ b/grant-tracking/api/android/grant-tracking.api
@@ -1,0 +1,5 @@
+public final class dev/brewkits/grant/tracking/GrantTracking {
+	public static final field INSTANCE Ldev/brewkits/grant/tracking/GrantTracking;
+	public final fun initialize ()V
+}
+

--- a/grant-tracking/api/grant-tracking.klib.api
+++ b/grant-tracking/api/grant-tracking.klib.api
@@ -1,0 +1,11 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <dev.brewkits:grant-tracking>
+final object dev.brewkits.grant.tracking/GrantTracking { // dev.brewkits.grant.tracking/GrantTracking|null[0]
+    final fun initialize() // dev.brewkits.grant.tracking/GrantTracking.initialize|initialize(){}[0]
+}

--- a/grant-tracking/build.gradle.kts
+++ b/grant-tracking/build.gradle.kts
@@ -1,0 +1,133 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kover)
+    id("maven-publish")
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.cyclonedx)
+}
+
+group = "dev.brewkits"
+version = "2.3.0"
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_17)
+                }
+            }
+        }
+    }
+
+    jvmToolchain(17)
+
+    // Every public declaration must state its visibility and return type explicitly.
+    // The ABI gate below records what the public surface IS; this stops something
+    // becoming public by accident in the first place.
+    explicitApi()
+
+    // Public API surface lock (KGP 2.4 built-in ABI validation, klib included).
+    // Dumps live in api/ and are verified by CI. See grant-core for rationale.
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+    }
+
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64()
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "GrantTracking"
+            isStatic = true
+            linkerOpts("-weak_framework", "AppTrackingTransparency")
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":grant-core"))
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
+        }
+    }
+}
+
+android {
+    namespace = "dev.brewkits.grant.tracking"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "MavenCentralLocal"
+            url = uri(layout.buildDirectory.dir("maven-central-staging"))
+        }
+    }
+
+    publications.configureEach {
+        (this as? MavenPublication)?.let {
+            groupId = "dev.brewkits"
+            version = "2.3.0"
+
+            pom {
+                name.set("KMP Grant Tracking")
+                description.set("App Tracking Transparency (ATT) permission handler for KMP Grant")
+                url.set("https://github.com/brewkits/grant")
+
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("brewkits")
+                        name.set("Brewkits")
+                        email.set("vietnguyentuan@gmail.com")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:git://github.com/brewkits/Grant.git")
+                    developerConnection.set("scm:git:ssh://github.com/brewkits/Grant.git")
+                    url.set("https://github.com/brewkits/Grant")
+                }
+            }
+        }
+    }
+}
+
+// Software Bill of Materials for this published artifact.
+// ./gradlew cyclonedxBom  ->  <module>/build/reports/bom.json
+//
+// Applied per published module rather than at the root: the root task would also walk
+// :demo, whose Kotlin/Native and Compose configurations CycloneDX 1.4 cannot resolve, and
+// a per-artifact BOM is the right granularity for consumers anyway.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    // Runtime dependencies are the ones that actually reach a consumer.
+    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
+    notCompatibleWithConfigurationCache("CycloneDX 1.4 resolves configurations at execution time")
+}

--- a/grant-tracking/src/androidMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
+++ b/grant-tracking/src/androidMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
@@ -1,0 +1,18 @@
+package dev.brewkits.grant.tracking
+
+/**
+ * Entry point for initializing the Grant Tracking module.
+ */
+public actual object GrantTracking {
+    /**
+     * No-op on Android. There is no runtime permission for cross-app tracking: the advertising
+     * ID is gated by `com.google.android.gms.permission.AD_ID`, an install-time permission with
+     * no dialog. `grant-core` already reports `APP_TRACKING` as GRANTED there without a prompt.
+     *
+     * Adding this module to a shared KMP source set is therefore safe — it simply does nothing
+     * on Android, exactly like `grant-contacts` and the other iOS-isolation modules.
+     */
+    public actual fun initialize() {
+        // No-op
+    }
+}

--- a/grant-tracking/src/commonMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
+++ b/grant-tracking/src/commonMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
@@ -1,0 +1,13 @@
+package dev.brewkits.grant.tracking
+
+/**
+ * Entry point for initializing the Grant Tracking (App Tracking Transparency) module.
+ */
+public expect object GrantTracking {
+    /**
+     * Initializes the App Tracking Transparency handler.
+     * Must be called before requesting [dev.brewkits.grant.AppGrant.APP_TRACKING].
+     * It is safe to call this multiple times.
+     */
+    public fun initialize()
+}

--- a/grant-tracking/src/commonTest/kotlin/dev/brewkits/grant/tracking/GrantTrackingTest.kt
+++ b/grant-tracking/src/commonTest/kotlin/dev/brewkits/grant/tracking/GrantTrackingTest.kt
@@ -1,0 +1,24 @@
+package dev.brewkits.grant.tracking
+
+import kotlin.test.Test
+
+/**
+ * `initialize()` must be safe to call repeatedly and from any platform in a shared source set —
+ * on Android it is a documented no-op, since there is no runtime permission for cross-app
+ * tracking there. This mirrors `GrantContactsTest` for the other opt-in modules.
+ *
+ * The iOS behaviour that actually matters — `ATTrackingManager` status mapping and the
+ * foreground-active requirement — is not unit-testable: `trackingAuthorizationStatus` reads
+ * real device/simulator TCC state that a test cannot set, and the prompt requires a human. It
+ * is covered by `TrackingPermissionHandler`'s documented mapping and must be exercised on a
+ * device before this module is advertised as verified.
+ */
+class GrantTrackingTest {
+
+    @Test
+    fun initialize_is_idempotent() {
+        GrantTracking.initialize()
+        GrantTracking.initialize()
+        GrantTracking.initialize()
+    }
+}

--- a/grant-tracking/src/iosMain/kotlin/dev/brewkits/grant/handlers/TrackingPermissionHandler.kt
+++ b/grant-tracking/src/iosMain/kotlin/dev/brewkits/grant/handlers/TrackingPermissionHandler.kt
@@ -1,0 +1,101 @@
+package dev.brewkits.grant.handlers
+
+import dev.brewkits.grant.GrantStatus
+import dev.brewkits.grant.utils.GrantLogger
+import dev.brewkits.grant.utils.hasInfoPlistKey
+import dev.brewkits.grant.utils.mainContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.AppTrackingTransparency.ATTrackingManager
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatus
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatusAuthorized
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatusDenied
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatusNotDetermined
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatusRestricted
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationState
+import kotlin.coroutines.resume
+
+private const val TAG = "TrackingPermissionHandler"
+private const val USAGE_KEY = "NSUserTrackingUsageDescription"
+
+/**
+ * Handles App Tracking Transparency via `ATTrackingManager`.
+ *
+ * **Why ATT is isolated in its own module:**
+ * Linking `AppTrackingTransparency.framework` makes Apple require
+ * [USAGE_KEY] in Info.plist for *every* app that links it — including apps that never track.
+ * Keeping it out of `grant-core` is the same isolation `grant-contacts`, `grant-calendar` and
+ * `grant-motion` exist for (Issues #38, #45).
+ *
+ * **Both denial states map to [GrantStatus.DENIED_ALWAYS], but they are not the same thing**,
+ * and the log says which one it is because the remedy differs:
+ * - `denied` — this user declined for this app. Recoverable in Settings → *this app* →
+ *   Allow Tracking.
+ * - `restricted` — the device-level "Allow Apps to Request to Track" switch is off, or a
+ *   configuration profile forbids it. The prompt will not appear at all, and the user cannot
+ *   change it from the app's own settings page. Sending them to app settings would be a dead
+ *   end, so the log points at the right screen instead.
+ */
+internal class TrackingPermissionHandler : PermissionHandler {
+
+    override fun checkStatus(): GrantStatus {
+        if (!hasInfoPlistKey(TAG, USAGE_KEY)) return GrantStatus.DENIED_ALWAYS
+        return mapStatus(ATTrackingManager.trackingAuthorizationStatus)
+    }
+
+    override suspend fun request(): GrantStatus {
+        if (!hasInfoPlistKey(TAG, USAGE_KEY)) return GrantStatus.DENIED_ALWAYS
+
+        warnIfNotActive()
+
+        return suspendCancellableCoroutine { cont ->
+            ATTrackingManager.requestTrackingAuthorizationWithCompletionHandler { _ ->
+                // Re-read the real status rather than trusting the callback's raw value — the
+                // same convention the Contacts and Calendar handlers already follow.
+                mainContinuation<GrantStatus> { s -> cont.resume(s) }.invoke(checkStatus())
+            }
+        }
+    }
+
+    /**
+     * iOS only presents the ATT prompt while the app is foreground-**active**. Called during
+     * launch, from the background, or behind a modal transition, the completion handler fires
+     * immediately with the *current* status and no prompt is shown — and because the status is
+     * then still `notDetermined`, this is easy to mistake for "the user dismissed it".
+     *
+     * There is exactly one ask per install, so a request spent this way is spent for good.
+     * Warning is the honest thing to do: Grant cannot defer the call on the app's behalf
+     * without guessing when a good moment is, and guessing wrong would burn the ask too.
+     */
+    private fun warnIfNotActive() {
+        val state = UIApplication.sharedApplication.applicationState
+        if (state != UIApplicationState.UIApplicationStateActive) {
+            GrantLogger.w(
+                TAG,
+                "requestTrackingAuthorization() called while the app is not foreground-active " +
+                    "(state=$state). iOS will not show the prompt and will return the current " +
+                    "status immediately — and the one ask this install gets is spent. Request " +
+                    "it from a screen the user is looking at.",
+            )
+        }
+    }
+
+    private fun mapStatus(raw: ATTrackingManagerAuthorizationStatus): GrantStatus = when (raw) {
+        ATTrackingManagerAuthorizationStatusAuthorized -> GrantStatus.GRANTED
+        ATTrackingManagerAuthorizationStatusNotDetermined -> GrantStatus.NOT_DETERMINED
+        ATTrackingManagerAuthorizationStatusDenied -> {
+            GrantLogger.d(TAG, "Tracking denied by this user for this app — recoverable in Settings > (this app) > Allow Tracking.")
+            GrantStatus.DENIED_ALWAYS
+        }
+        ATTrackingManagerAuthorizationStatusRestricted -> {
+            GrantLogger.d(
+                TAG,
+                "Tracking is restricted device-wide (Settings > Privacy & Security > Tracking > " +
+                    "Allow Apps to Request to Track is off, or an MDM profile forbids it). The " +
+                    "prompt will not appear and this app's own settings page cannot change it.",
+            )
+            GrantStatus.DENIED_ALWAYS
+        }
+        else -> GrantStatus.NOT_DETERMINED
+    }
+}

--- a/grant-tracking/src/iosMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
+++ b/grant-tracking/src/iosMain/kotlin/dev/brewkits/grant/tracking/GrantTracking.kt
@@ -1,0 +1,21 @@
+package dev.brewkits.grant.tracking
+
+import dev.brewkits.grant.AppGrant
+import dev.brewkits.grant.handlers.IosPermissionHandlerRegistry
+import dev.brewkits.grant.handlers.TrackingPermissionHandler
+
+/**
+ * Entry point for initializing the Grant Tracking module.
+ */
+public actual object GrantTracking {
+    private var isInitialized = false
+
+    /**
+     * Registers the App Tracking Transparency handler for iOS.
+     */
+    public actual fun initialize() {
+        if (isInitialized) return
+        isInitialized = true
+        IosPermissionHandlerRegistry.register(AppGrant.APP_TRACKING.identifier, TrackingPermissionHandler())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":grant-compose")
 include(":demo")
 include(":grant-bluetooth")
 include(":grant-location-always")
+include(":grant-tracking")
 include(":grant-desktop")
 // Deliberately not "grant-desktop-harness" — see desktop-harness/build.gradle.kts's header
 // comment for why this module must never be mistaken for a published library.


### PR DESCRIPTION
## Summary

Adds **App Tracking Transparency** as `AppGrant.APP_TRACKING`, backed on iOS by a new opt-in module `grant-tracking`. This closes the one genuine gap the newest-OS coverage audit found.

**Why this one and not the others.** Most permissions Grant doesn't model are reachable through `RawPermission` — on Android. On iOS they are not: `RawPermission.request()` has no generic API to call, so it logs and returns `NOT_DETERMINED`. The only route was hand-writing a `PermissionHandler`, which is most of the work. ATT is both iOS-only and needed by nearly every commercial app, so it earns first-class support.

## Feasibility verified before writing code

The same check that ruled AlarmKit *out* in #74:

| Framework | `Headers/` | Reachable from Kotlin/Native? |
|---|---|---|
| `AlarmKit` | umbrella header, version symbols only | ❌ Swift-only |
| `AppTrackingTransparency` | real `ATTrackingManager.h` with `trackingAuthorizationStatus`, `requestTrackingAuthorizationWithCompletionHandler:`, 0–3 enum | ✅ yes |

## Why a separate module

Linking `AppTrackingTransparency` makes Apple require `NSUserTrackingUsageDescription` in **every** app that links it — including apps that never track. Same isolation reason `grant-contacts`/`grant-calendar`/`grant-motion` exist (Issues #38, #45). The boundary is forced by the platform, not chosen for style.

## Two details that are easy to get wrong

**`restricted` ≠ `denied`**, though both map to `DENIED_ALWAYS`:

| State | Meaning | Remedy |
|---|---|---|
| `denied` | this user declined for this app | Settings → *this app* → Allow Tracking |
| `restricted` | device-wide "Allow Apps to Request to Track" is off, or an MDM profile | **Not** reachable from the app's settings page — sending the user there is a dead end |

The log says which one it is, because the fix differs.

**`request()` warns when the app is not foreground-active.** iOS shows the ATT prompt only in that state. Called during launch or from the background, the completion fires immediately with the current status, no prompt appears — and the *single ask an install gets is spent*. Grant cannot defer the call without guessing a good moment (guessing wrong burns the ask too), so it warns rather than deciding for the app.

## Android: a no-op that is honest, not a stub

`APP_TRACKING` reports `GRANTED` on Android with no prompt. Cross-app tracking is gated there by `com.google.android.gms.permission.AD_ID` — an **install-time** permission, auto-granted, with no dialog to show. Users opt out in system settings, which surfaces as a zeroed advertising ID rather than a permission denial Grant could observe. Web and JVM fall through their existing unsupported paths to `DENIED_ALWAYS`.

## Two existing tests caught the enum addition — which is what they are for

- **`GrantTypeTest`** pinned the count at 20 → now 21, plus an `APP_TRACKING` entry.
- **`IosHandlerPatternTest`** mirrors `handlerFor()` to assert dispatch exhaustiveness. While adding `APP_TRACKING` there, its `SCHEDULE_EXACT_ALARM` entry was also corrected: #74 gave that permission its own handler, so it no longer belongs in the `ALWAYS_GRANTED` group.

## Also updated

`grant-tracking` added to the publish script's `MODULES` array, the Dokka aggregation, README (20 → 21 permissions) and the installation guide. ABI dumps regenerated — the enum entry is additive on all three surfaces.

## Not claimed

**Not yet verified on a device**, and `ROADMAP.md` says so. The status mapping and the foreground-active rule are unit-untestable: `trackingAuthorizationStatus` reads real TCC state a test cannot set, and the prompt needs a human. The module should be exercised on a device before being advertised as verified.

Full root build (`build allTests checkKotlinAbi`) green.

## Health Connect — not in this PR, needs a design decision first

The audit's other Bucket-B item turns out to be blocked on an architecture choice rather than effort, and two constraints in the current design force it:

1. **`GrantPermission` is `sealed`** — a `grant-health` module *cannot* add a new permission type.
2. **Android has no handler registry** (unlike iOS's `IosPermissionHandlerRegistry` and the JVM's `DesktopPermissionHandlerRegistry`), so there is no existing extension point for an opt-in Android module to plug into.

Health Connect also cannot use `requestPermissions()` at all — it needs `PermissionController.createRequestPermissionResultContract()` plus a rationale Activity that **the consuming app** must declare (`androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE`), which a library cannot do on the app's behalf. Details and options are recorded under v2.7.0 in `ROADMAP.md`.
