### PR TITLE
ci: gate every PR into main (not just pushes to it)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,25 @@
 name: CI
 
-# Cost control: build workflows run only when code lands on main (i.e. on merge),
-# not on every branch push or pull request. macOS runners bill at a 10x minute
-# multiplier, so per-PR runs were the bulk of the spend. Use the Actions tab's
-# "Run workflow" button (workflow_dispatch) to validate a branch on demand.
+# Gates every PR into main, not just pushes to it. This repo is PUBLIC, so GitHub-hosted
+# Actions runners — including macOS, at any wall-clock length — are unmetered: there is no
+# minute quota to protect here (confirmed against GitHub's own billing docs: the 10x macOS
+# multiplier only draws down a private repo's paid/included quota; public repos are unlimited
+# on GitHub-hosted runners). An earlier version of this comment cited "cost control" as the
+# reason PRs were not gated — that reasoning did not apply to this repo and left every PR
+# merged into main unverified by CI; the only gate was a local build run by hand.
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
+
+# Cancel a superseded run when new commits land on the same PR/branch — no cost impact on a
+# public repo, but keeps the Actions tab and PR checks list readable instead of accumulating
+# stale in-flight runs for commits nobody cares about anymore.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:
@@ -33,11 +45,22 @@ jobs:
 
       # -x checkKotlinAbi: the ABI check is wired into `check` (and so into `build`), but its
       # klib dumps cover the Apple targets, which Kotlin/Native cannot compile on a Linux
-      # runner. ios.yml runs checkKotlinAbi on macOS against both surfaces.
+      # runner. ios.yml runs checkKotlinAbi on macOS against every module's surface, including
+      # grant-tracking and grant-desktop's — that task aggregates automatically at the root
+      # (verified: `./gradlew checkKotlinAbi --dry-run` lists every module with abiValidation,
+      # with no per-module listing required here).
       - name: Build grant-core
         run: ./gradlew :grant-core:build -x checkKotlinAbi
 
-      - name: Run tests (all modules)
+      # Aggregates every test task the Linux host can run across every module, including ones
+      # this workflow never names explicitly — verified with `./gradlew allTests --dry-run`
+      # before relying on it: grant-core's jsBrowserTest/wasmJsBrowserTest/jvmTest,
+      # grant-desktop's jvmTest (its own host-detection branches safely to "no bridge" off
+      # macOS), and grant-tracking's Android-side tests are all pulled in by this one line
+      # with no per-target wiring. Apple/iOS test tasks are absent from the aggregation on a
+      # Linux host (KGP disables targets the host cannot build), not silently skipped —
+      # ios.yml is what verifies those.
+      - name: Run tests (all modules, all Linux-buildable targets)
         run: ./gradlew allTests
 
       - name: Build grant-compose
@@ -46,11 +69,42 @@ jobs:
       - name: Build grant-core-koin
         run: ./gradlew :grant-core-koin:build -x checkKotlinAbi
 
+      - name: Build grant-contacts
+        run: ./gradlew :grant-contacts:build -x checkKotlinAbi
+
+      - name: Build grant-calendar
+        run: ./gradlew :grant-calendar:build -x checkKotlinAbi
+
+      - name: Build grant-motion
+        run: ./gradlew :grant-motion:build -x checkKotlinAbi
+
       - name: Build grant-bluetooth
         run: ./gradlew :grant-bluetooth:build -x checkKotlinAbi
 
       - name: Build grant-location-always
         run: ./gradlew :grant-location-always:build -x checkKotlinAbi
+
+      # New in v2.4.0 (App Tracking Transparency, PR #75). Android target only here — grant-tracking
+      # also declares iosArm64/iosX64/iosSimulatorArm64, which this Linux host cannot cross-compile;
+      # ios.yml's root checkKotlinAbi and its iOS test step cover the Apple side.
+      - name: Build grant-tracking
+        run: ./gradlew :grant-tracking:build -x checkKotlinAbi
+
+      # New in v2.4.0 (macOS Tier 2, PR #72). Only the jvmMain compile + jvmTest are Linux-buildable
+      # here — the macosArm64 shared-library target is Kotlin/Native cross-compiled to Apple, which
+      # only a macOS host can do; KGP disables that target on Linux rather than failing the build,
+      # so this step is a real (if partial) signal, not a no-op. ios.yml builds the full target set.
+      - name: Build grant-desktop (JVM side)
+        run: ./gradlew :grant-desktop:build -x checkKotlinAbi
+
+      # desktop-harness is the manual Tier-2 verification harness (see its build.gradle.kts —
+      # deliberately unpublished, not part of MODULES in create-grant-maven-bundle-auto.sh). It
+      # is pure JVM + Compose Desktop, so compiling it needs no macOS host even though *running*
+      # it to see a real TCC dialog does. A compile check here catches a broken reference to
+      # grant-core/grant-desktop's API on every PR instead of only when someone next runs it by
+      # hand on a Mac.
+      - name: Compile desktop-harness
+        run: ./gradlew :desktop-harness:compileKotlin
 
       - name: Build demo app
         run: ./gradlew :demo:assembleDebug

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,13 +1,19 @@
 name: Code Quality
 
-# Cost control: build workflows run only when code lands on main (i.e. on merge),
-# not on every branch push or pull request. macOS runners bill at a 10x minute
-# multiplier, so per-PR runs were the bulk of the spend. Use the Actions tab's
-# "Run workflow" button (workflow_dispatch) to validate a branch on demand.
+# Gates every PR into main, not just pushes to it. This repo is PUBLIC, so GitHub-hosted
+# Actions runners are unmetered — see ci.yml's comment for the full reasoning (an earlier
+# version of this file cited "cost control" as the reason PRs were unguarded; that did not
+# apply here).
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -31,8 +37,23 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # Every module with an androidTarget, so a lint issue introduced in any of them is
+      # caught here rather than only in the module the previous version of this line happened
+      # to name. grant-desktop has no androidTarget (jvm() + macosArm64 only) and is correctly
+      # absent; grant-tracking (v2.4.0, ATT) is new here.
       - name: Run Android Lint
-        run: ./gradlew :demo:lintDebug :grant-core:lintDebug :grant-compose:lintDebug :grant-bluetooth:lintDebug :grant-location-always:lintDebug
+        run: >-
+          ./gradlew
+          :demo:lintDebug
+          :grant-core:lintDebug
+          :grant-compose:lintDebug
+          :grant-core-koin:lintDebug
+          :grant-contacts:lintDebug
+          :grant-calendar:lintDebug
+          :grant-motion:lintDebug
+          :grant-bluetooth:lintDebug
+          :grant-location-always:lintDebug
+          :grant-tracking:lintDebug
 
       - name: Upload lint reports
         if: always()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,13 +1,22 @@
 name: iOS Build
 
-# Cost control: build workflows run only when code lands on main (i.e. on merge),
-# not on every branch push or pull request. macOS runners bill at a 10x minute
-# multiplier, so per-PR runs were the bulk of the spend. Use the Actions tab's
-# "Run workflow" button (workflow_dispatch) to validate a branch on demand.
+# Gates every PR into main, not just pushes to it. This repo is PUBLIC, so GitHub-hosted
+# Actions runners — including macOS, at any wall-clock length — are unmetered: there is no
+# minute quota to protect here (the 10x macOS multiplier only draws down a private repo's
+# paid/included quota; public repos are unlimited on GitHub-hosted runners). An earlier
+# version of this comment cited "cost control" as the reason PRs were not gated — that
+# reasoning did not apply to this repo and left every PR's Apple-target surface, including the
+# klib ABI dumps, unverified until after merge.
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: ios-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-ios:
@@ -39,15 +48,43 @@ jobs:
       - name: Build iOS Framework
         run: ./gradlew :grant-core:linkDebugFrameworkIosArm64 :grant-core:linkDebugFrameworkIosSimulatorArm64
 
+      # Every module with a real iosTest suite, not just the three that had one when this line
+      # was first written. grant-contacts and grant-motion are listed even though — as of this
+      # change — they have no iosTest files yet (PR #77 adds them): calling the test task on a
+      # module with none still succeeds with zero tests run, so this line does not need editing
+      # again the moment that PR merges. grant-tracking (ATT, PR #75) is listed for the same
+      # forward-looking reason. Keeping this list current matters: on Android these modules'
+      # commonTest suites run against a documented no-op (see each module's GrantXxx.initialize()),
+      # so their real, platform-specific logic is ONLY exercised here.
       - name: Run iOS Tests
-        run: ./gradlew :grant-core:iosSimulatorArm64Test :grant-bluetooth:iosSimulatorArm64Test :grant-location-always:iosSimulatorArm64Test
+        run: >-
+          ./gradlew
+          :grant-core:iosSimulatorArm64Test
+          :grant-bluetooth:iosSimulatorArm64Test
+          :grant-location-always:iosSimulatorArm64Test
+          :grant-calendar:iosSimulatorArm64Test
+          :grant-contacts:iosSimulatorArm64Test
+          :grant-motion:iosSimulatorArm64Test
+          :grant-tracking:iosSimulatorArm64Test
 
       - name: Build Compose iOS Framework
         run: ./gradlew :grant-compose:linkDebugFrameworkIosArm64 :grant-compose:linkDebugFrameworkIosSimulatorArm64 || true
 
+      # New in v2.4.0 (macOS Tier 2, PR #72). This is the ONLY CI job that can build it — the
+      # macosArm64 shared-library target is Kotlin/Native cross-compiled to Apple, which only a
+      # macOS host can do (ci.yml's Linux job builds this module's jvmMain/jvmTest half only).
+      # jvmTest includes NativeBridgeAbiProbeTest, which reads the real AVFoundation
+      # authorization status through the built dylib on this runner — the actual ABI-safety
+      # check documented in ROADMAP.md v2.6.0, not a stub.
+      - name: Build and test grant-desktop (macOS)
+        run: ./gradlew :grant-desktop:build -x checkKotlinAbi
+
       # Runs here, not in ci.yml: the klib dumps cover the three Apple targets, which
       # only a macOS runner can compile. Fails the build when the public API surface
       # drifts from the committed api/*.api dumps — regenerate with ./gradlew updateKotlinAbi.
+      # No per-module listing needed: this aggregates every module with abiValidation at the
+      # root, including grant-tracking and grant-desktop automatically (verified with
+      # `./gradlew checkKotlinAbi --dry-run` before relying on that instead of naming modules).
       - name: Check public API surface (ABI)
         run: ./gradlew checkKotlinAbi
 


### PR DESCRIPTION
## Why

All three workflows (`ci.yml`, `ios.yml`, `code-quality.yml`) previously ran only on `push: [main]` — a PR could merge with **zero CI signal**, and the only gate was whatever the author happened to run locally by hand.

## What changed

- Added `pull_request: branches: [main]` to `ci.yml`, `ios.yml`, `code-quality.yml`.
- Added a `concurrency` group per workflow so a new commit on the same PR cancels the previous in-flight run instead of piling up.
- Rewrote each workflow's header comment: the old "cost control" rationale for leaving PRs ungated does not apply here — **this repo is public, so GitHub-hosted Actions runners (including macOS, at any length) are unmetered** (confirmed against GitHub's billing docs — public repos get unlimited minutes on GitHub-hosted runners; the 10x macOS multiplier only draws against a *private* repo's paid quota).

While gating these, also closed coverage gaps each workflow had quietly accumulated as modules were added without anyone revisiting the trigger:

- **`ci.yml`**: added build steps for `grant-contacts`, `grant-calendar`, `grant-motion` (previously missing entirely from this workflow), `grant-tracking` (v2.4.0 ATT), `grant-desktop`'s JVM half, and a compile-check for `desktop-harness`.
- **`ios.yml`**: expanded the iOS test step from 3 modules to all 7 with a real (or imminently real) `iosTest` suite — core, bluetooth, location-always, calendar, contacts, motion, tracking — and added a macOS build+test step for `grant-desktop`, the only CI job that can build its `macosArm64` shared-library target and exercise `NativeBridgeAbiProbeTest` against the real AVFoundation authorization API through the built dylib.
- **`code-quality.yml`**: expanded Android Lint from 5 modules to the 10 that actually declare an `androidTarget` — verified per-module by grepping each `build.gradle.kts` for the `androidLibrary`/`androidTarget` plugin, not by re-deriving the list from a flaky `tasks --all` loop (which gave contradictory results on repeated runs — root-caused to Gradle daemon contention when called in a tight bash loop, not a real task-graph difference).

## Verification

Every step in this diff was run for real before opening this PR, on this machine (macOS + Xcode available), matching what each workflow will run in CI:

- `./gradlew :demo:lintDebug :grant-core:lintDebug :grant-compose:lintDebug :grant-core-koin:lintDebug :grant-contacts:lintDebug :grant-calendar:lintDebug :grant-motion:lintDebug :grant-bluetooth:lintDebug :grant-location-always:lintDebug :grant-tracking:lintDebug` → **BUILD SUCCESSFUL**
- `./gradlew :grant-contacts:build :grant-calendar:build :grant-motion:build :grant-tracking:build :grant-desktop:build -x checkKotlinAbi` → **BUILD SUCCESSFUL**
- `./gradlew :desktop-harness:compileKotlin` → **BUILD SUCCESSFUL**
- `./gradlew allTests` → **BUILD SUCCESSFUL**
- `./gradlew :grant-core:iosSimulatorArm64Test :grant-bluetooth:iosSimulatorArm64Test :grant-location-always:iosSimulatorArm64Test :grant-calendar:iosSimulatorArm64Test :grant-contacts:iosSimulatorArm64Test :grant-motion:iosSimulatorArm64Test :grant-tracking:iosSimulatorArm64Test` → **BUILD SUCCESSFUL** (contacts/motion run 0 tests — expected, see note below)
- `./gradlew checkKotlinAbi` (root) → **BUILD SUCCESSFUL**

**Note:** `grant-contacts`/`grant-motion` currently have no `iosTest` files — those are added by PR #77, not yet merged. `ios.yml`'s comment documents this explicitly; listing them now means the workflow needs no edit the moment #77 merges (calling the test task on a module with zero tests still succeeds).

## Not in scope here

`ci-coverage.yml` was left untouched — its module list wasn't part of this pass and isn't required for the PR-gating goal.